### PR TITLE
Hook for direct context usage + rename Context to FormContext

### DIFF
--- a/src/demo/context/SubmitIfValid.js
+++ b/src/demo/context/SubmitIfValid.js
@@ -1,12 +1,12 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
-import { Context as FormContext } from '../../lib';
+import { useFormContext } from '../../lib';
 
 import Submit from '../components/Submit';
 import './SubmitIfValid.css';
 
 const SubmitIfValid = (props) => {
-	const { valid } = useContext(FormContext); // using React Hooks
+	const { valid } = useFormContext(); // using React Hooks
 	return <Submit className="SubmitIfValid" disabled={!valid} {...props} />;
 };
 

--- a/src/lib/Field/Field.js
+++ b/src/lib/Field/Field.js
@@ -3,7 +3,7 @@ import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 
-import { withContext } from '../Form/Context';
+import { withFormContext } from '../Form/Context';
 
 class Field extends PureComponent {
 	memoGetClassnames = memoize((className, isInvalid, isSubmitted, isTouched) => classnames(
@@ -55,7 +55,7 @@ class Field extends PureComponent {
 			...props
 		} = this.props;
 
-		return withContext((form) => (
+		return withFormContext((form) => (
 			<Component
 				className={this.getClassnames(form)}
 				name={name}

--- a/src/lib/FieldError/FieldError.js
+++ b/src/lib/FieldError/FieldError.js
@@ -3,7 +3,7 @@ import memoize from 'memoize-one';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-import { withContext } from '../Form/Context';
+import { withFormContext } from '../Form/Context';
 import getErrorMessage from './getErrorMessage';
 
 class FieldError extends PureComponent {
@@ -44,7 +44,7 @@ class FieldError extends PureComponent {
 			name,
 		} = this.props;
 
-		return withContext((form) => {
+		return withFormContext((form) => {
 			const fieldErrors = form.getFieldErrors(name);
 			if (!fieldErrors.length) return null;
 

--- a/src/lib/Form/Context.js
+++ b/src/lib/Form/Context.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 const FormContext = React.createContext();
 
 export default FormContext;
+
+export const useFormContext = () => useContext(FormContext);
 
 export const withFormContext = (cb) => <FormContext.Consumer>{cb}</FormContext.Consumer>;

--- a/src/lib/Form/Context.js
+++ b/src/lib/Form/Context.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Context = React.createContext();
+const FormContext = React.createContext();
 
-export default Context;
+export default FormContext;
 
-export const withContext = (cb) => <Context.Consumer>{cb}</Context.Consumer>;
+export const withFormContext = (cb) => <FormContext.Consumer>{cb}</FormContext.Consumer>;

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -6,7 +6,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import scrollToElement from 'scroll-to-element';
 
-import Context from './Context';
+import FormContext from './Context';
 import {
 	createAjv,
 	filterByFieldNameWithWildcard,
@@ -219,7 +219,7 @@ class Form extends PureComponent {
 		} = this.props;
 
 		return (
-			<Context.Provider value={this.getContext()}>
+			<FormContext.Provider value={this.getContext()}>
 				<FormComponent
 					className={this.getClassnames()}
 					onSubmit={this.handleSubmit}
@@ -228,7 +228,7 @@ class Form extends PureComponent {
 				>
 					{ children }
 				</FormComponent>
-			</Context.Provider>
+			</FormContext.Provider>
 		);
 	}
 }

--- a/src/lib/Form/__mocks__/Context.js
+++ b/src/lib/Form/__mocks__/Context.js
@@ -14,4 +14,4 @@ export default {
 	Consumer,
 };
 
-export const withContext = jest.fn().mockImplementation((cb) => <Consumer>{cb}</Consumer>);
+export const withFormContext = jest.fn().mockImplementation((cb) => <Consumer>{cb}</Consumer>);

--- a/src/lib/Form/index.js
+++ b/src/lib/Form/index.js
@@ -1,2 +1,3 @@
 export { default } from './Form';
-export { default as Context } from './Context';
+export * from './Context';
+export { default as FormContext } from './Context';


### PR DESCRIPTION
Related to #2 

New feature:
**useFormContext**
See updated [context usage example](https://github.com/53js/react-jsonschema-form-validation/tree/master/src/demo/context) 

This pr introduces also a breaking change about Context export which is renamed :
Context becomes FormContext
withContext becomes withFormContext