### PR TITLE
feat(FieldError): announce errors via role="alert" + fix react peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"typescript": "^6.0.3"
 	},
 	"peerDependencies": {
-		"react": ">=15"
+		"react": ">=16.8"
 	},
 	"resolutions": {
 		"dts-bundle-generator/typescript": "^6.0.3"

--- a/src/lib/FieldError/FieldError.js
+++ b/src/lib/FieldError/FieldError.js
@@ -112,7 +112,7 @@ class FieldError extends PureComponent {
 			if (!fieldErrors.length) return null;
 
 			return (
-				<Component className={this.getClassnames(form)} {...props}>
+				<Component className={this.getClassnames(form)} role="alert" {...props}>
 					{
 						children
 						|| this.getFieldErrorMessage(fieldErrors[0], form)

--- a/src/lib/FieldError/FieldError.test.js
+++ b/src/lib/FieldError/FieldError.test.js
@@ -101,6 +101,26 @@ it('should add class isSubmitted if form is submitted', () => {
 	expect(fieldError.find('.Jfv_FieldError').hasClass('isSubmitted')).toBe(true);
 });
 
+it('should have role="alert" by default so errors are announced to screen readers', () => {
+	const context = {
+		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
+		isFieldTouched: jest.fn(),
+	};
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const fieldError = mount(<FieldError name="username" />);
+	expect(fieldError.find('.Jfv_FieldError').prop('role')).toBe('alert');
+});
+
+it('should allow to override role via props', () => {
+	const context = {
+		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
+		isFieldTouched: jest.fn(),
+	};
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const fieldError = mount(<FieldError name="username" role="status" />);
+	expect(fieldError.find('.Jfv_FieldError').prop('role')).toBe('status');
+});
+
 it('should add class isTouched if field is touched', () => {
 	const context = {
 		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),

--- a/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
+++ b/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
@@ -10,6 +10,7 @@ exports[`should match snapshot 1`] = `
   <mockConstructor>
     <div
       className="Jfv_FieldError"
+      role="alert"
     />
   </mockConstructor>
 </FieldError>


### PR DESCRIPTION
Fixes part of #57 (a11y).

- Add `role="alert"` as a default on the element rendered by `<FieldError>`, so screen readers announce validation errors when they appear. Placed before the props spread, so consumers can still override it (test covers both).
- Fix `peerDependencies.react`: `>=15` was wrong — the code uses `createContext` (16.3+) and `useContext` (16.8+). Now `>=16.8`.

Tests: 6 suites, 65 tests (2 new), 5 snapshots, all green (`CI=true yarn test:runtime`).

## Release / follow-up notes (from self-review)
- **Publish as ≥ 0.7.0, not a patch**: narrowing the React peer range from `>=15` to `>=16.8` makes `npm install` fail (ERESOLVE) for consumers still on React <16.8 (they were already broken at runtime).
- Follow-ups tracked in #57: verify announcement with a real screen reader (visibility is CSS-gated by `.isSubmitted`, not mount-gated), README mention of the new default `role`, and `aria-invalid`/`aria-describedby` wiring on `<Field>` (blocked by #55).