### PR TITLE
fix(helpers): convert every array index in error paths; escape wildcard prefix

### DIFF
--- a/src/lib/Form/helpers.js
+++ b/src/lib/Form/helpers.js
@@ -159,7 +159,7 @@ export const formatErrors = (errors) => (errors || []).map((error) => {
 
 	formatted.field = formatted.field
 		.replace(/^\./, '')
-		.replace(/\[([0-9]+)\]/, '.$1');
+		.replace(/\[([0-9]+)\]/g, '.$1');
 
 	return formatted;
 });
@@ -178,7 +178,10 @@ export const filterByFieldNameWithWildcard = (fields, fieldName) => {
 	/** @type {RegExp | undefined} */
 	let regex;
 	if (/\*$/.test(fieldName)) {
-		regex = new RegExp(`^${fieldName.replace(/\*$/, '')}`);
+		// Escape regex metacharacters so a prefix like `user.` matches the
+		// literal dot instead of any character (`user.*` must not match `userX`).
+		const prefix = fieldName.replace(/\*$/, '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		regex = new RegExp(`^${prefix}`);
 	}
 
 	return fields.filter((e) => {

--- a/src/lib/Form/helpers.test.js
+++ b/src/lib/Form/helpers.test.js
@@ -125,6 +125,19 @@ describe('.filterByFieldNameWithWildcard(fields, fieldName)', () => {
 		expect(helpers.filterByFieldNameWithWildcard(fields, 'user.*'))
 			.toEqual([{ field: 'user.email' }]);
 	});
+
+	it('should not crash when the wildcard prefix contains an unclosed bracket', () => {
+		const fields = [
+			{ field: 'items[0].label' },
+			{ field: 'items[1].label' },
+			{ field: 'other' },
+		];
+
+		// The unescaped prefix `items[0` used to throw a SyntaxError
+		// (unterminated character class) when compiled to a RegExp.
+		expect(helpers.filterByFieldNameWithWildcard(fields, 'items[0*'))
+			.toEqual([{ field: 'items[0].label' }]);
+	});
 });
 
 describe('.getInputCheckboxValue(target)', () => {

--- a/src/lib/Form/helpers.test.js
+++ b/src/lib/Form/helpers.test.js
@@ -81,6 +81,11 @@ describe('.formatErrors(errors)', () => {
 		const errors = [{ dataPath: 'arr[0].input' }];
 		expect(helpers.formatErrors(errors)[0].field).toStrictEqual('arr.0.input');
 	});
+
+	it('should convert every array index when the path contains several', () => {
+		const errors = [{ dataPath: 'items[0].tags[1]' }];
+		expect(helpers.formatErrors(errors)[0].field).toStrictEqual('items.0.tags.1');
+	});
 });
 
 describe('.filterByFieldNameWithWildcard(fields, fieldName)', () => {
@@ -108,6 +113,17 @@ describe('.filterByFieldNameWithWildcard(fields, fieldName)', () => {
 
 		expect(helpers.filterByFieldNameWithWildcard(fields, 'name*'))
 			.toEqual([{ field: 'name' }, { field: 'name1' }]);
+	});
+
+	it('should treat the dot in a wildcard prefix as a literal character', () => {
+		const fields = [
+			{ field: 'user.email' },
+			{ field: 'userX' },
+			{ field: 'user' },
+		];
+
+		expect(helpers.filterByFieldNameWithWildcard(fields, 'user.*'))
+			.toEqual([{ field: 'user.email' }]);
 	});
 });
 


### PR DESCRIPTION
## Observable defects

1. **formatErrors**: the bracket-to-dot `.replace(/\[([0-9]+)\]/, '.$1')` lacked the `g` flag, so only the first array index was converted — an AJV error on `items[0].tags[1]` produced `field = "items.0.tags[1]"`, and `<FieldError name="items.0.tags.1">` never matched.
2. **filterByFieldNameWithWildcard**: the wildcard prefix went raw into `new RegExp` — the dot in `user.*` matched any character, so `userX` was wrongly matched. A prefix with an unclosed bracket (e.g. `items[0*`) even threw `SyntaxError: Unterminated character class`.

## Fix

- Add the `g` flag to the index-conversion replace.
- Escape regex metacharacters in the wildcard prefix before building the regex (also fixes the SyntaxError crash).

## Tests

- New test: `items[0].tags[1]` formats to `items.0.tags.1` (fails on master with `items.0.tags[1]`).
- New test: `user.*` matches `user.email` but not `userX` (fails on master with `userX` included).
- New test: `items[0*` filters without crashing (fails on master with `SyntaxError: Unterminated character class`).
- `CI=true yarn test:runtime`: 6 suites, 66 tests (63 before + 3 new), 5 snapshots — all green.

## Heads-up for consumers

If you worked around the old bug by writing bracket-notation paths in `<FieldError name>` (e.g. `name="items.0.tags[1]"`), those names will no longer match: error paths are now fully dot-normalized (`items.0.tags.1`).