### PR TITLE
fix(Form): check every name in isFieldInvalid; guard and focus scrollToFirstError

### DIFF
--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -311,12 +311,7 @@ class Form extends PureComponent {
 	 */
 	isFieldInvalid = (fieldNames) => {
 		const names = Array.isArray(fieldNames) ? fieldNames : [fieldNames];
-		// The spread here only propagates `names[0]` — `getFieldErrors` reads
-		// a single `fieldNames` argument, so any element beyond the first is
-		// ignored at runtime. Behavior preserved as-is; the tuple cast just
-		// makes the spread legal for TS.
-		const tuple = /** @type {[string]} */ (names);
-		return this.getFieldErrors(...tuple).length > 0;
+		return this.getFieldErrors(names).length > 0;
 	}
 
 	/**
@@ -347,7 +342,13 @@ class Form extends PureComponent {
 		const { errors } = this.state;
 		const firstError = errors[0];
 		const element = document.getElementsByName(firstError.field)[0];
+		// No DOM element may carry the error's name (custom field, error on a
+		// nested object): skip scrolling instead of forwarding `undefined`.
+		if (!element) return;
 		scrollToElement(element, scrollOptions);
+		// Move keyboard focus to the first invalid field (a11y). The scroll
+		// itself is handled above, hence `preventScroll`.
+		element.focus({ preventScroll: true });
 	}
 
 	/** @param {FormEvent} event */

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -309,10 +309,7 @@ class Form extends PureComponent {
 	 * @param {string | string[]} fieldNames
 	 * @returns {boolean}
 	 */
-	isFieldInvalid = (fieldNames) => {
-		const names = Array.isArray(fieldNames) ? fieldNames : [fieldNames];
-		return this.getFieldErrors(names).length > 0;
-	}
+	isFieldInvalid = (fieldNames) => this.getFieldErrors(fieldNames).length > 0
 
 	/**
 	 * @param {string | string[]} fieldNames
@@ -341,6 +338,9 @@ class Form extends PureComponent {
 		const { scrollOptions } = this.props;
 		const { errors } = this.state;
 		const firstError = errors[0];
+		// Nothing to scroll to when the form has no errors (e.g. direct call
+		// through a ref on a valid form).
+		if (!firstError) return;
 		const element = document.getElementsByName(firstError.field)[0];
 		// No DOM element may carry the error's name (custom field, error on a
 		// nested object): skip scrolling instead of forwarding `undefined`.

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -313,12 +313,30 @@ describe('Form.scrollToFirstError()', () => {
 			{ attachTo: container },
 		);
 
-		wrapper.find('form').simulate('submit', { preventDefault() {} });
+		try {
+			wrapper.find('form').simulate('submit', { preventDefault() {} });
 
-		expect(document.activeElement).toBe(document.getElementById('test-type'));
+			expect(document.activeElement).toBe(document.getElementById('test-type'));
+		} finally {
+			wrapper.detach();
+			document.body.removeChild(container);
+		}
+	});
 
-		wrapper.detach();
-		document.body.removeChild(container);
+	it('should not throw when called directly while the form has no errors', () => {
+		const data = { type: 'te' };
+
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={testSchema}
+			/>,
+		);
+
+		expect(() => {
+			wrapper.instance().scrollToFirstError();
+		}).not.toThrow();
 	});
 });
 

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -241,6 +241,85 @@ describe('Form.isFieldInvalid(fieldNames)', () => {
 		expect(wrapper.instance().isFieldInvalid('type')).toBe(false);
 		expect(wrapper.instance().isFieldInvalid(['name'])).toBe(true);
 	});
+
+	it('should check every name of the list, not only the first one', () => {
+		// 'type' is valid, only 'name' (2nd element) has an error: a naive
+		// implementation checking names[0] only would return false here.
+		const data = {
+			type: 'te',
+			name: 'HE',
+		};
+
+		const newSchema = {
+			type: 'object',
+			properties: {
+				type: { type: 'string', enum: ['te', 'ta'] },
+				name: { type: 'string', minLength: 6 },
+			},
+			required: [
+				'type',
+				'name',
+			],
+		};
+
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={newSchema}
+			/>,
+		);
+
+		expect(wrapper.instance().isFieldInvalid(['type', 'name'])).toBe(true);
+	});
+});
+
+describe('Form.scrollToFirstError()', () => {
+	it('should not throw when no DOM element matches the first error field', () => {
+		const data = { type: 'invalid-value' };
+
+		// No <Field name="type"> rendered: document.getElementsByName('type')
+		// is empty when the submit fails.
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={testSchema}
+			/>,
+		);
+
+		expect(() => {
+			wrapper.find('form').simulate('submit', { preventDefault() {} });
+		}).not.toThrow();
+	});
+
+	it('should move focus to the first invalid field after a failed submit', () => {
+		const data = { type: 'invalid-value' };
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={testSchema}
+			>
+				<Field
+					id="test-type"
+					name="type"
+					type="text"
+				/>
+			</Form>,
+			{ attachTo: container },
+		);
+
+		wrapper.find('form').simulate('submit', { preventDefault() {} });
+
+		expect(document.activeElement).toBe(document.getElementById('test-type'));
+
+		wrapper.detach();
+		document.body.removeChild(container);
+	});
 });
 
 describe('Form.isFieldTouched(fieldName)', () => {


### PR DESCRIPTION
## Fixes

- **isFieldInvalid**: `isFieldInvalid(['a', 'b'])` only checked the first name (`getFieldErrors(...tuple)` dropped the rest). Now passes the array directly — `getFieldErrors` already accepts one.
- **scrollToFirstError guard**: when no DOM element carries the first error's name (custom field, required error on a nested object), `undefined` was forwarded to `scrollToElement`. Now returns early.
- **Keyboard a11y (#57)**: after scrolling, focus moves to the first invalid field via `element.focus({ preventScroll: true })`.

## Tests

3 new tests, each verified to fail against the un-fixed code:
- multi-name `isFieldInvalid` with the error on the **second** name only
- invalid submit with no matching DOM element does not throw
- after an invalid submit, `document.activeElement` is the invalid field

`CI=true yarn test:runtime`: 6 suites, 66 tests (63 on master), 5 snapshots — all green.