### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,11 @@ yarn start
 
 ## Tests
 
-Run these before opening a PR — CI runs the same commands.
+Run these before opening a PR — CI runs the runtime suite, a type-check
+matrix equivalent to `yarn test:types`, and the `yarn dist` build.
 
 ```bash
-# Jest unit tests (via react-scripts). 6 suites, 75 tests at the time of writing.
+# Jest unit tests (via react-scripts)
 yarn test:runtime
 
 # Watch mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+Thanks for helping improve react-jsonschema-form-validation. This document
+describes the actual workflow used in this repository — nothing more.
+
+## Prerequisites
+
+- Node 20 (see `.nvmrc` — `nvm use` picks it up)
+- Yarn 1 (the repo uses `yarn.lock`)
+
+## Setup
+
+```bash
+yarn install
+```
+
+To play with the demo app while developing (Create React App):
+
+```bash
+yarn start
+```
+
+## Tests
+
+Run these before opening a PR — CI runs the same commands.
+
+```bash
+# Jest unit tests (via react-scripts). 6 suites, 75 tests at the time of writing.
+yarn test:runtime
+
+# Watch mode
+yarn test:runtime:watch
+
+# TypeScript check of the repo sources
+yarn type-check
+
+# Type-level tests against @types/react 16, 17, 18 and 19
+yarn test:types
+
+# Everything (runtime + types)
+yarn test
+```
+
+`yarn test:types` runs `test-types/check-matrix.sh`: it rebuilds `dist/`,
+packs the library into a tarball, installs it inside `test-types/`, then
+type-checks `positive.tsx` / `negative.tsx` against each supported
+`@types/react` major. It restores `@types/react@16` on exit, even on failure.
+See `test-types/README.md` for details.
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/), matching the
+existing history:
+
+```
+fix(Form): guard and focus scrollToFirstError
+feat(FieldError): announce errors to screen readers via role="alert"
+docs: reference CHANGELOG in README
+test(helpers): lock the SyntaxError fix for unclosed brackets
+build(deps): bump actions/checkout from 4.4.0 to 7.0.1
+ci: pin actions to SHA
+```
+
+## Pull Requests
+
+- Target the `master` branch.
+- CI (GitHub Actions, `.github/workflows/ci.yml`) must pass: the `build` job
+  runs `yarn type-check`, `yarn test:runtime` and `yarn dist`; the `types`
+  matrix type-checks the built bundle against `@types/react` 16/17/18/19.
+- Keep PRs focused; add or update tests for behavior changes.
+- Update `CHANGELOG.md` when the change is user-facing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+This is a small library maintained on a best-effort basis. Only the **latest
+minor release published on npm** receives security fixes. Older releases are
+not patched — please upgrade to the latest version before reporting an issue.
+
+## Reporting a Vulnerability
+
+Please **do not open a public issue** for security problems.
+
+Instead, use GitHub's private vulnerability reporting for this repository:
+
+[https://github.com/53js/react-jsonschema-form-validation/security/advisories/new](https://github.com/53js/react-jsonschema-form-validation/security/advisories/new)
+
+Include what you can: affected version, a minimal reproduction, and the impact
+you foresee.
+
+## What to Expect
+
+We aim to acknowledge reports within a few business days and to publish a fix
+for confirmed vulnerabilities as soon as reasonably possible. This is a
+best-effort commitment from a small team, not a guaranteed SLA.


### PR DESCRIPTION
Part of #57 (§6, governance docs).

## Changes

- **SECURITY.md** (new): short, realistic policy — only the latest published minor is supported, vulnerabilities reported privately via GitHub Security Advisories, best-effort response (no SLA promises).
- **CONTRIBUTING.md** (new): documents only what the repo actually does — `yarn install`, `yarn test:runtime` (Jest via react-scripts), `yarn test:types` (@types/react 16/17/18/19 matrix via `test-types/check-matrix.sh`), `yarn type-check`, Conventional Commits (style taken from git log), PRs to `master` with green GitHub Actions CI.
- **README.md**: untouched — badges were checked and are already clean (npm / GitHub Actions CI / MIT); no stale CircleCI or Code Climate badges remain.

## Verification

- `CI=true yarn test:runtime`: exit 0 — 6 suites, 75 tests passed.
- `yarn type-check`: exit 0.
- Every command documented in CONTRIBUTING.md was either executed locally or cross-checked against `package.json`, `.github/workflows/ci.yml`, and `test-types/check-matrix.sh`.

Note (out of scope): `test-types/check-matrix.sh` and `test-types/README.md` still contain stale CircleCI comments; left for a follow-up since this PR touches no source files.