### PR TITLE
feat(a11y): wire aria-invalid and aria-describedby between Field and FieldError

### DIFF
--- a/src/lib/Field/Field.js
+++ b/src/lib/Field/Field.js
@@ -17,6 +17,7 @@ import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 
+import getFieldErrorId from '../a11y';
 import { withFormContext } from '../Form/Context';
 
 /**
@@ -190,8 +191,15 @@ class Field extends PureComponent {
 			...props
 		} = this.props;
 
+		// Both aria-* defaults sit BEFORE {...props} so users can override
+		// them. aria-describedby always points to the matching <FieldError>
+		// id: when no error is displayed the id does not exist, and
+		// assistive technologies ignore dangling references — simpler than
+		// rendering it conditionally.
 		return withFormContext((form) => (
 			<Component
+				aria-describedby={getFieldErrorId(name)}
+				aria-invalid={form.isFieldInvalid(name) || undefined}
 				className={this.getClassnames(form)}
 				name={name}
 				onBlur={this.memoGetOnBlurHandler(form.touch, name, onBlur)}

--- a/src/lib/Field/Field.js
+++ b/src/lib/Field/Field.js
@@ -17,7 +17,6 @@ import memoize from 'memoize-one';
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 
-import getFieldErrorId from '../a11y';
 import { withFormContext } from '../Form/Context';
 
 /**
@@ -73,6 +72,7 @@ import { withFormContext } from '../Form/Context';
  *
  * @typedef {{
  *   name: string,
+ *   'aria-describedby'?: string | null,
  *   children?: ReactNode,
  *   className?: string,
  *   component?: ElementType,
@@ -181,6 +181,7 @@ class Field extends PureComponent {
 
 	render() {
 		const {
+			'aria-describedby': ariaDescribedBy,
 			children,
 			className,
 			component: Component = 'input',
@@ -191,19 +192,29 @@ class Field extends PureComponent {
 			...props
 		} = this.props;
 
-		// Both aria-* defaults sit BEFORE {...props} so users can override
-		// them. They are gated on the same reveal condition as the visual
-		// error styling (touched or submitted): before that, the matching
-		// <FieldError> is only hidden via CSS, and display:none elements
-		// directly referenced by aria-describedby ARE included in the
-		// accessible description — without the gate, screen readers would
-		// announce "invalid entry" plus the full error message on focus in
-		// a pristine form, with nothing visible on screen.
+		// Both ARIA attributes are gated on the same reveal condition as the
+		// visual error styling (touched or submitted): before that, the
+		// matching <FieldError> is only hidden via CSS, and display:none
+		// elements directly referenced by aria-describedby ARE included in
+		// the accessible description — without the gate, screen readers
+		// would announce "invalid entry" plus the full error message on
+		// focus in a pristine form, with nothing visible on screen.
+		//
+		// aria-invalid is a plain DEFAULT (before {...props}), overridable.
+		// aria-describedby is a COMPUTED value (after {...props}): the
+		// user-supplied IDREFs come first (e.g. a hint text id), then the
+		// error ids registered by this form's <FieldError>s once revealed —
+		// merge, not override (React Aria / Reach UI pattern). Fully
+		// disabling the wiring is therefore not possible via override; if
+		// ever needed it will be a dedicated prop.
 		return withFormContext((form) => {
 			const revealed = form.isFieldTouched(name) || form.isSubmitted;
+			const describedBy = [
+				ariaDescribedBy,
+				revealed ? form.getFieldErrorDescribedBy(name) : undefined,
+			].filter(Boolean).join(' ') || undefined;
 			return (
 				<Component
-					aria-describedby={revealed ? getFieldErrorId(name) : undefined}
 					aria-invalid={revealed && form.isFieldInvalid(name) ? true : undefined}
 					className={this.getClassnames(form)}
 					name={name}
@@ -211,6 +222,7 @@ class Field extends PureComponent {
 					onChange={this.memoGetOnChangeHandler(onChange, form.handleFieldChange, name)}
 					ref={forwardedRef}
 					{...props}
+					aria-describedby={describedBy}
 				>
 					{children}
 				</Component>
@@ -220,6 +232,7 @@ class Field extends PureComponent {
 }
 
 Field.propTypes = {
+	'aria-describedby': PropTypes.string,
 	children: PropTypes.node,
 	className: PropTypes.string,
 	component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
@@ -233,6 +246,7 @@ Field.propTypes = {
 };
 
 Field.defaultProps = {
+	'aria-describedby': null,
 	children: null,
 	className: '',
 	component: 'input',

--- a/src/lib/Field/Field.js
+++ b/src/lib/Field/Field.js
@@ -192,24 +192,30 @@ class Field extends PureComponent {
 		} = this.props;
 
 		// Both aria-* defaults sit BEFORE {...props} so users can override
-		// them. aria-describedby always points to the matching <FieldError>
-		// id: when no error is displayed the id does not exist, and
-		// assistive technologies ignore dangling references — simpler than
-		// rendering it conditionally.
-		return withFormContext((form) => (
-			<Component
-				aria-describedby={getFieldErrorId(name)}
-				aria-invalid={form.isFieldInvalid(name) || undefined}
-				className={this.getClassnames(form)}
-				name={name}
-				onBlur={this.memoGetOnBlurHandler(form.touch, name, onBlur)}
-				onChange={this.memoGetOnChangeHandler(onChange, form.handleFieldChange, name)}
-				ref={forwardedRef}
-				{...props}
-			>
-				{children}
-			</Component>
-		));
+		// them. They are gated on the same reveal condition as the visual
+		// error styling (touched or submitted): before that, the matching
+		// <FieldError> is only hidden via CSS, and display:none elements
+		// directly referenced by aria-describedby ARE included in the
+		// accessible description — without the gate, screen readers would
+		// announce "invalid entry" plus the full error message on focus in
+		// a pristine form, with nothing visible on screen.
+		return withFormContext((form) => {
+			const revealed = form.isFieldTouched(name) || form.isSubmitted;
+			return (
+				<Component
+					aria-describedby={revealed ? getFieldErrorId(name) : undefined}
+					aria-invalid={revealed && form.isFieldInvalid(name) ? true : undefined}
+					className={this.getClassnames(form)}
+					name={name}
+					onBlur={this.memoGetOnBlurHandler(form.touch, name, onBlur)}
+					onChange={this.memoGetOnChangeHandler(onChange, form.handleFieldChange, name)}
+					ref={forwardedRef}
+					{...props}
+				>
+					{children}
+				</Component>
+			);
+		});
 	}
 }
 

--- a/src/lib/Field/Field.test.js
+++ b/src/lib/Field/Field.test.js
@@ -78,6 +78,45 @@ it('should add class isInvalid if field is invalid', () => {
 	expect(field.find('.Jfv_Field').hasClass('isInvalid')).toBe(true);
 });
 
+it('should set aria-invalid when the field is invalid', () => {
+	const context = {
+		isFieldInvalid: jest.fn(() => true),
+		isFieldTouched: jest.fn(),
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const field = mount(<Field name="username" />);
+	expect(field.find('input').prop('aria-invalid')).toBe(true);
+	expect(field.find('input').getDOMNode().getAttribute('aria-invalid')).toBe('true');
+});
+
+it('should not render aria-invalid when the field is valid', () => {
+	const field = mount(<Field name="username" />);
+	expect(field.find('input').prop('aria-invalid')).toBe(undefined);
+	expect(field.find('input').getDOMNode().hasAttribute('aria-invalid')).toBe(false);
+});
+
+it('should allow to override aria-invalid via props', () => {
+	const context = {
+		isFieldInvalid: jest.fn(() => true),
+		isFieldTouched: jest.fn(),
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const field = mount(<Field aria-invalid={false} name="username" />);
+	expect(field.find('input').prop('aria-invalid')).toBe(false);
+});
+
+it('should point aria-describedby at the matching FieldError id by default', () => {
+	const field = mount(<Field name="username" />);
+	expect(field.find('input').prop('aria-describedby')).toBe('jfv-error-username');
+});
+
+it('should allow to override aria-describedby via props', () => {
+	const field = mount(<Field aria-describedby="my-hint" name="username" />);
+	expect(field.find('input').prop('aria-describedby')).toBe('my-hint');
+});
+
 it('Default component input can be changed', () => {
 	const Component = () => 'component';
 	const field = mount(<Field component={Component} name="username" />);

--- a/src/lib/Field/Field.test.js
+++ b/src/lib/Field/Field.test.js
@@ -78,10 +78,24 @@ it('should add class isInvalid if field is invalid', () => {
 	expect(field.find('.Jfv_Field').hasClass('isInvalid')).toBe(true);
 });
 
-it('should set aria-invalid when the field is invalid', () => {
+it('should not expose aria-invalid nor aria-describedby while untouched and unsubmitted, even if invalid', () => {
 	const context = {
 		isFieldInvalid: jest.fn(() => true),
-		isFieldTouched: jest.fn(),
+		isFieldTouched: jest.fn(() => false),
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const field = mount(<Field name="username" />);
+	expect(field.find('input').prop('aria-invalid')).toBe(undefined);
+	expect(field.find('input').getDOMNode().hasAttribute('aria-invalid')).toBe(false);
+	expect(field.find('input').prop('aria-describedby')).toBe(undefined);
+	expect(field.find('input').getDOMNode().hasAttribute('aria-describedby')).toBe(false);
+});
+
+it('should set aria-invalid when the field is invalid and touched', () => {
+	const context = {
+		isFieldInvalid: jest.fn(() => true),
+		isFieldTouched: jest.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
@@ -90,7 +104,26 @@ it('should set aria-invalid when the field is invalid', () => {
 	expect(field.find('input').getDOMNode().getAttribute('aria-invalid')).toBe('true');
 });
 
-it('should not render aria-invalid when the field is valid', () => {
+it('should set aria-invalid and aria-describedby when the field is invalid and the form submitted', () => {
+	const context = {
+		isFieldInvalid: jest.fn(() => true),
+		isFieldTouched: jest.fn(() => false),
+		isSubmitted: true,
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const field = mount(<Field name="username" />);
+	expect(field.find('input').prop('aria-invalid')).toBe(true);
+	expect(field.find('input').prop('aria-describedby')).toBe('jfv-error-username');
+});
+
+it('should not render aria-invalid when the field is valid, even touched', () => {
+	const context = {
+		isFieldInvalid: jest.fn(() => false),
+		isFieldTouched: jest.fn(() => true),
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const field = mount(<Field name="username" />);
 	expect(field.find('input').prop('aria-invalid')).toBe(undefined);
 	expect(field.find('input').getDOMNode().hasAttribute('aria-invalid')).toBe(false);
@@ -99,7 +132,7 @@ it('should not render aria-invalid when the field is valid', () => {
 it('should allow to override aria-invalid via props', () => {
 	const context = {
 		isFieldInvalid: jest.fn(() => true),
-		isFieldTouched: jest.fn(),
+		isFieldTouched: jest.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
@@ -107,12 +140,24 @@ it('should allow to override aria-invalid via props', () => {
 	expect(field.find('input').prop('aria-invalid')).toBe(false);
 });
 
-it('should point aria-describedby at the matching FieldError id by default', () => {
+it('should point aria-describedby at the matching FieldError id once touched', () => {
+	const context = {
+		isFieldInvalid: jest.fn(),
+		isFieldTouched: jest.fn(() => true),
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const field = mount(<Field name="username" />);
 	expect(field.find('input').prop('aria-describedby')).toBe('jfv-error-username');
 });
 
 it('should allow to override aria-describedby via props', () => {
+	const context = {
+		isFieldInvalid: jest.fn(),
+		isFieldTouched: jest.fn(() => true),
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const field = mount(<Field aria-describedby="my-hint" name="username" />);
 	expect(field.find('input').prop('aria-describedby')).toBe('my-hint');
 });

--- a/src/lib/Field/Field.test.js
+++ b/src/lib/Field/Field.test.js
@@ -35,6 +35,7 @@ it('should call onBlur handler when blurred', () => {
 
 it('should add class isSubmitted if form is submitted', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(),
 		isFieldInvalid: jest.fn(),
 		isFieldTouched: jest.fn(),
 	};
@@ -50,6 +51,7 @@ it('should add class isSubmitted if form is submitted', () => {
 
 it('should add class isTouched if field is touched', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(),
 		isFieldInvalid: jest.fn(),
 		isFieldTouched: jest.fn(),
 	};
@@ -80,6 +82,7 @@ it('should add class isInvalid if field is invalid', () => {
 
 it('should not expose aria-invalid nor aria-describedby while untouched and unsubmitted, even if invalid', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
 		isFieldInvalid: jest.fn(() => true),
 		isFieldTouched: jest.fn(() => false),
 	};
@@ -90,10 +93,12 @@ it('should not expose aria-invalid nor aria-describedby while untouched and unsu
 	expect(field.find('input').getDOMNode().hasAttribute('aria-invalid')).toBe(false);
 	expect(field.find('input').prop('aria-describedby')).toBe(undefined);
 	expect(field.find('input').getDOMNode().hasAttribute('aria-describedby')).toBe(false);
+	expect(context.getFieldErrorDescribedBy).not.toHaveBeenCalled();
 });
 
 it('should set aria-invalid when the field is invalid and touched', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(),
 		isFieldInvalid: jest.fn(() => true),
 		isFieldTouched: jest.fn(() => true),
 	};
@@ -106,6 +111,7 @@ it('should set aria-invalid when the field is invalid and touched', () => {
 
 it('should set aria-invalid and aria-describedby when the field is invalid and the form submitted', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
 		isFieldInvalid: jest.fn(() => true),
 		isFieldTouched: jest.fn(() => false),
 		isSubmitted: true,
@@ -114,11 +120,13 @@ it('should set aria-invalid and aria-describedby when the field is invalid and t
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const field = mount(<Field name="username" />);
 	expect(field.find('input').prop('aria-invalid')).toBe(true);
-	expect(field.find('input').prop('aria-describedby')).toBe('jfv-error-username');
+	expect(field.find('input').prop('aria-describedby')).toBe('jfv1-error-username');
+	expect(context.getFieldErrorDescribedBy).toHaveBeenCalledWith('username');
 });
 
 it('should not render aria-invalid when the field is valid, even touched', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(),
 		isFieldInvalid: jest.fn(() => false),
 		isFieldTouched: jest.fn(() => true),
 	};
@@ -131,6 +139,7 @@ it('should not render aria-invalid when the field is valid, even touched', () =>
 
 it('should allow to override aria-invalid via props', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(),
 		isFieldInvalid: jest.fn(() => true),
 		isFieldTouched: jest.fn(() => true),
 	};
@@ -140,26 +149,42 @@ it('should allow to override aria-invalid via props', () => {
 	expect(field.find('input').prop('aria-invalid')).toBe(false);
 });
 
-it('should point aria-describedby at the matching FieldError id once touched', () => {
+it('should point aria-describedby at the ids registered by the FieldErrors once touched', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
 		isFieldInvalid: jest.fn(),
 		isFieldTouched: jest.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const field = mount(<Field name="username" />);
-	expect(field.find('input').prop('aria-describedby')).toBe('jfv-error-username');
+	expect(field.find('input').prop('aria-describedby')).toBe('jfv1-error-username');
+	expect(context.getFieldErrorDescribedBy).toHaveBeenCalledWith('username');
 });
 
-it('should allow to override aria-describedby via props', () => {
+it('should merge a user aria-describedby with the registered error ids when revealed', () => {
 	const context = {
+		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
 		isFieldInvalid: jest.fn(),
 		isFieldTouched: jest.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const field = mount(<Field aria-describedby="my-hint" name="username" />);
+	expect(field.find('input').prop('aria-describedby')).toBe('my-hint jfv1-error-username');
+});
+
+it('should keep only the user aria-describedby while not revealed', () => {
+	const context = {
+		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
+		isFieldInvalid: jest.fn(),
+		isFieldTouched: jest.fn(() => false),
+	};
+
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const field = mount(<Field aria-describedby="my-hint" name="username" />);
 	expect(field.find('input').prop('aria-describedby')).toBe('my-hint');
+	expect(context.getFieldErrorDescribedBy).not.toHaveBeenCalled();
 });
 
 it('Default component input can be changed', () => {

--- a/src/lib/Field/__snapshots__/Field.test.js.snap
+++ b/src/lib/Field/__snapshots__/Field.test.js.snap
@@ -5,6 +5,7 @@ exports[`should match snapshot 1`] = `
   name="username"
 >
   <Field
+    aria-describedby={null}
     className=""
     component="input"
     forwardedRef={null}

--- a/src/lib/Field/__snapshots__/Field.test.js.snap
+++ b/src/lib/Field/__snapshots__/Field.test.js.snap
@@ -14,7 +14,6 @@ exports[`should match snapshot 1`] = `
   >
     <mockConstructor>
       <input
-        aria-describedby="jfv-error-username"
         className="Jfv_Field"
         name="username"
         onBlur={[Function]}

--- a/src/lib/Field/__snapshots__/Field.test.js.snap
+++ b/src/lib/Field/__snapshots__/Field.test.js.snap
@@ -14,6 +14,7 @@ exports[`should match snapshot 1`] = `
   >
     <mockConstructor>
       <input
+        aria-describedby="jfv-error-username"
         className="Jfv_Field"
         name="username"
         onBlur={[Function]}

--- a/src/lib/FieldError/FieldError.js
+++ b/src/lib/FieldError/FieldError.js
@@ -27,6 +27,7 @@ import getErrorMessage from './getErrorMessage';
  *   className?: string,
  *   component?: ElementType,
  *   errorMessages?: ErrorMessagesMap | null,
+ *   id?: string | null,
  *   name: string,
  * }} FieldErrorBaseProps
  */
@@ -41,6 +42,9 @@ import getErrorMessage from './getErrorMessage';
  *                       map declared at the `<Form>` level (see `ErrorMessagesMap`).
  * - `component`       — element rendered when an error is present (default `'div'`).
  * - `children`        — replaces the auto-generated message when provided.
+ * - `id`              — overrides the default deterministic id; the effective id is
+ *                       registered in the form, so `<Field>`'s `aria-describedby`
+ *                       follows it automatically.
  *
  * @template {ElementType} [C = 'div']
  * @typedef {(
@@ -50,8 +54,38 @@ import getErrorMessage from './getErrorMessage';
  * )} FieldErrorProps
  */
 
-/** @extends {PureComponent<FieldErrorBaseProps>} */
-class FieldError extends PureComponent {
+/**
+ * Props of the internal implementation: the public props plus the form
+ * context injected as a regular prop by the wrapper below.
+ *
+ * @typedef {FieldErrorBaseProps & { form: FormContextValue }} FieldErrorInnerProps
+ */
+
+// Module-level counter giving each mounted <FieldError> a stable identity
+// (`key`) in the Form's id registry.
+let nextFieldErrorKey = 0;
+const createFieldErrorKey = () => {
+	nextFieldErrorKey += 1;
+	return `jfve${nextFieldErrorKey}`;
+};
+
+/**
+ * Internal implementation. Receives the form context as a `form` prop —
+ * injected by the `withFormContext` render-prop in the public wrapper —
+ * so the registration lifecycles below can use it. (`static contextType`
+ * would need the real React context object, which the unit tests replace
+ * with a plain mock; the render-prop also matches the existing style.)
+ *
+ * Registration is independent from rendering, on purpose: the registry
+ * entry exists as long as the component is mounted, even while no error is
+ * displayed (render returns `null`) — an `aria-describedby` IDREF pointing
+ * to an absent element is ignored by assistive technologies.
+ *
+ * @extends {PureComponent<FieldErrorInnerProps>}
+ */
+class FieldErrorInner extends PureComponent {
+	fieldErrorKey = createFieldErrorKey();
+
 	memoGetClassnames = memoize((
 		/** @type {string | undefined} */ className,
 		/** @type {boolean} */ isSubmitted,
@@ -74,11 +108,34 @@ class FieldError extends PureComponent {
 		return getErrorMessage(error, errorMessages);
 	})
 
-	/**
-	 * @param {FormContextValue} form
-	 */
-	getClassnames = (form) => {
-		const { className, name } = this.props;
+	// Registration happens in effects only — never during render. The
+	// resulting Form setState flushes before the browser paints, so no
+	// intermediate state is visible.
+	componentDidMount() {
+		const { form, name } = this.props;
+		form.registerFieldError(this.fieldErrorKey, name, this.getId());
+	}
+
+	/** @param {FieldErrorInnerProps} prevProps */
+	componentDidUpdate(prevProps) {
+		// Anti-loop guard: re-register only when the (name, id) pair
+		// actually changed — paired with the identical-entry bail-out in
+		// Form.registerFieldError.
+		const { form, name } = this.props;
+		const prevId = prevProps.id != null
+			? prevProps.id
+			: getFieldErrorId(prevProps.form.formId, prevProps.name);
+		if (prevProps.name === name && prevId === this.getId()) return;
+		form.registerFieldError(this.fieldErrorKey, name, this.getId());
+	}
+
+	componentWillUnmount() {
+		const { form } = this.props;
+		form.unregisterFieldError(this.fieldErrorKey);
+	}
+
+	getClassnames = () => {
+		const { className, form, name } = this.props;
 		const { isFieldTouched, isSubmitted } = form;
 
 		return this.memoGetClassnames(
@@ -88,14 +145,22 @@ class FieldError extends PureComponent {
 		);
 	}
 
-	/**
-	 * @param {FormattedError} error
-	 * @param {FormContextValue} form
-	 */
-	getFieldErrorMessage = (error, form) => {
-		const { errorMessages: fieldErrorMessages } = this.props;
+	/** @param {FormattedError} error */
+	getFieldErrorMessage = (error) => {
+		const { errorMessages: fieldErrorMessages, form } = this.props;
 		const { errorMessages: formErrorMessages } = form;
 		return this.memoGetFieldErrorMessage(error, formErrorMessages, fieldErrorMessages);
+	}
+
+	/**
+	 * Effective id: the user-supplied `id` prop, or the deterministic
+	 * default derived from (formId, name). The same value is registered in
+	 * the Form registry, so a custom id never desynchronizes the
+	 * `aria-describedby` of the matching `<Field>`.
+	 */
+	getId = () => {
+		const { form, id, name } = this.props;
+		return id != null ? id : getFieldErrorId(form.formId, name);
 	}
 
 	render() {
@@ -104,38 +169,73 @@ class FieldError extends PureComponent {
 			className,
 			component: Component = 'div',
 			errorMessages,
+			form,
+			id,
 			name,
 			...props
 		} = this.props;
 
-		return withFormContext((form) => {
-			const fieldErrors = form.getFieldErrors(name);
-			if (!fieldErrors.length) return null;
+		const fieldErrors = form.getFieldErrors(name);
+		if (!fieldErrors.length) return null;
 
-			// Default id matches the aria-describedby set by <Field> for the
-			// same `name`; declared before {...props} so users can override it.
-			return (
-				<Component
-					className={this.getClassnames(form)}
-					id={getFieldErrorId(name)}
-					role="alert"
-					{...props}
-				>
-					{
-						children
-						|| this.getFieldErrorMessage(fieldErrors[0], form)
-					}
-				</Component>
-			);
-		});
+		return (
+			<Component
+				className={this.getClassnames()}
+				id={this.getId()}
+				role="alert"
+				{...props}
+			>
+				{
+					children
+					|| this.getFieldErrorMessage(fieldErrors[0])
+				}
+			</Component>
+		);
 	}
 }
+
+FieldErrorInner.propTypes = {
+	children: PropTypes.node,
+	className: PropTypes.string,
+	component: PropTypes.elementType,
+	errorMessages: PropTypes.objectOf(PropTypes.func),
+	form: PropTypes.shape({
+		errorMessages: PropTypes.objectOf(PropTypes.func),
+		formId: PropTypes.string,
+		getFieldErrors: PropTypes.func.isRequired,
+		isFieldTouched: PropTypes.func.isRequired,
+		isSubmitted: PropTypes.bool,
+		registerFieldError: PropTypes.func.isRequired,
+		unregisterFieldError: PropTypes.func.isRequired,
+	}).isRequired,
+	id: PropTypes.string,
+	name: PropTypes.string.isRequired,
+};
+
+FieldErrorInner.defaultProps = {
+	children: null,
+	className: '',
+	component: 'div',
+	errorMessages: null,
+	id: null,
+};
+
+/**
+ * Public component: a thin wrapper reading the form context and passing it
+ * to the implementation as the `form` prop.
+ *
+ * @param {FieldErrorBaseProps} props
+ */
+const FieldError = (props) => withFormContext(
+	(form) => <FieldErrorInner {...props} form={form} />,
+);
 
 FieldError.propTypes = {
 	children: PropTypes.node,
 	className: PropTypes.string,
 	component: PropTypes.elementType,
 	errorMessages: PropTypes.objectOf(PropTypes.func),
+	id: PropTypes.string,
 	name: PropTypes.string.isRequired,
 };
 
@@ -144,9 +244,10 @@ FieldError.defaultProps = {
 	component: 'div',
 	errorMessages: null,
 	className: '',
+	id: null,
 };
 
-// Polymorphic re-typing: the class is non-generic internally (uses
+// Polymorphic re-typing: the implementation is non-generic internally (uses
 // `FieldErrorBaseProps`); the cast on the default export restores the
 // generic so consumers get autocomplete and type-checking on `component`'s
 // own props.

--- a/src/lib/FieldError/FieldError.js
+++ b/src/lib/FieldError/FieldError.js
@@ -13,6 +13,7 @@ import memoize from 'memoize-one';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
+import getFieldErrorId from '../a11y';
 import { withFormContext } from '../Form/Context';
 import getErrorMessage from './getErrorMessage';
 
@@ -111,8 +112,15 @@ class FieldError extends PureComponent {
 			const fieldErrors = form.getFieldErrors(name);
 			if (!fieldErrors.length) return null;
 
+			// Default id matches the aria-describedby set by <Field> for the
+			// same `name`; declared before {...props} so users can override it.
 			return (
-				<Component className={this.getClassnames(form)} role="alert" {...props}>
+				<Component
+					className={this.getClassnames(form)}
+					id={getFieldErrorId(name)}
+					role="alert"
+					{...props}
+				>
 					{
 						children
 						|| this.getFieldErrorMessage(fieldErrors[0], form)

--- a/src/lib/FieldError/FieldError.test.js
+++ b/src/lib/FieldError/FieldError.test.js
@@ -6,15 +6,27 @@ import FieldError from './FieldError';
 
 jest.mock('../Form/Context');
 
+// Minimal form context: the id registration lifecycles need `formId`,
+// `registerFieldError` and `unregisterFieldError` on every mount.
+const createContext = (overrides) => ({
+	formId: 'jfv1',
+	getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
+	isFieldTouched: jest.fn(),
+	registerFieldError: jest.fn(),
+	unregisterFieldError: jest.fn(),
+	...overrides,
+});
+
 it('should match snapshot', () => {
-	const context = {
+	const context = createContext({
 		getFieldErrors: jest.fn(() => [{ keyword: 'bad' }]),
-		isFieldTouched: jest.fn(),
-	};
+	});
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const fieldError = mount(<FieldError name="username" />);
-	expect(fieldError).toMatchSnapshot();
+	// Snapshot the rendered element only: the full wrapper would serialize
+	// the mocked `form` prop (jest.fn call records) — noisy and brittle.
+	expect(fieldError.find('div.Jfv_FieldError')).toMatchSnapshot();
 });
 
 it('should not be displayed if field has no error', () => {
@@ -23,14 +35,13 @@ it('should not be displayed if field has no error', () => {
 });
 
 it('should call error message of first error only if field has errors', () => {
-	const context = {
+	const context = createContext({
 		errorMessages: {
 			bad1: jest.fn(),
 			bad2: jest.fn(),
 		},
 		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }, { keyword: 'bad2' }]),
-		isFieldTouched: jest.fn(),
-	};
+	});
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	mount(<FieldError name="username" />);
@@ -39,14 +50,13 @@ it('should call error message of first error only if field has errors', () => {
 });
 
 it('should allow to extend and override error messages defined in form', () => {
-	const context = {
+	const context = createContext({
 		errorMessages: {
 			bad1: jest.fn(),
 			bad2: jest.fn(),
 		},
 		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }, { keyword: 'bad2' }]),
-		isFieldTouched: jest.fn(),
-	};
+	});
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const bad1Override = jest.fn();
@@ -73,10 +83,7 @@ it('should allow to extend and override error messages defined in form', () => {
 });
 
 it('should render children if providen', () => {
-	const context = {
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-		isFieldTouched: jest.fn(),
-	};
+	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const fieldError = mount(
 		<FieldError name="username">
@@ -87,10 +94,7 @@ it('should render children if providen', () => {
 });
 
 it('should add class isSubmitted if form is submitted', () => {
-	const context = {
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-		isFieldTouched: jest.fn(),
-	};
+	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	let fieldError = mount(<FieldError name="username" />);
 	expect(fieldError.find('.Jfv_FieldError').hasClass('isSubmitted')).toBe(false);
@@ -102,50 +106,93 @@ it('should add class isSubmitted if form is submitted', () => {
 });
 
 it('should have role="alert" by default so errors are announced to screen readers', () => {
-	const context = {
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-		isFieldTouched: jest.fn(),
-	};
+	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const fieldError = mount(<FieldError name="username" />);
 	expect(fieldError.find('.Jfv_FieldError').prop('role')).toBe('alert');
 });
 
 it('should allow to override role via props', () => {
-	const context = {
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-		isFieldTouched: jest.fn(),
-	};
+	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const fieldError = mount(<FieldError name="username" role="status" />);
 	expect(fieldError.find('.Jfv_FieldError').prop('role')).toBe('status');
 });
 
-it('should have a deterministic id derived from name so fields can reference it', () => {
-	const context = {
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-		isFieldTouched: jest.fn(),
-	};
+it('should render a deterministic id prefixed by the formId', () => {
+	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').prop('id')).toBe('jfv-error-username');
+	expect(fieldError.find('.Jfv_FieldError').prop('id')).toBe('jfv1-error-username');
 });
 
 it('should allow to override id via props', () => {
-	const context = {
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-		isFieldTouched: jest.fn(),
-	};
+	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	const fieldError = mount(<FieldError id="custom-id" name="username" />);
 	expect(fieldError.find('.Jfv_FieldError').prop('id')).toBe('custom-id');
 });
 
+it('should register its default id in the form on mount', () => {
+	const context = createContext();
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	mount(<FieldError name="username" />);
+	expect(context.registerFieldError).toHaveBeenCalledTimes(1);
+	expect(context.registerFieldError).toHaveBeenCalledWith(
+		expect.any(String),
+		'username',
+		'jfv1-error-username',
+	);
+});
+
+it('should register a custom id in the form so Field aria-describedby follows it', () => {
+	const context = createContext();
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	mount(<FieldError id="custom-id" name="username" />);
+	expect(context.registerFieldError).toHaveBeenCalledWith(
+		expect.any(String),
+		'username',
+		'custom-id',
+	);
+});
+
+it('should unregister its key from the form on unmount', () => {
+	const context = createContext();
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const fieldError = mount(<FieldError name="username" />);
+	const key = context.registerFieldError.mock.calls[0][0];
+
+	fieldError.unmount();
+	expect(context.unregisterFieldError).toHaveBeenCalledTimes(1);
+	expect(context.unregisterFieldError).toHaveBeenCalledWith(key);
+});
+
+it('should not re-register on updates that leave (name, id) unchanged', () => {
+	const context = createContext();
+	FormContext.Consumer
+		.mockImplementationOnce((props) => props.children(context))
+		.mockImplementationOnce((props) => props.children(context));
+	const fieldError = mount(<FieldError name="username" />);
+
+	fieldError.setProps({ className: 'other' });
+	expect(context.registerFieldError).toHaveBeenCalledTimes(1);
+});
+
+it('should re-register under the same key when its id changes', () => {
+	const context = createContext();
+	FormContext.Consumer
+		.mockImplementationOnce((props) => props.children(context))
+		.mockImplementationOnce((props) => props.children(context));
+	const fieldError = mount(<FieldError name="username" />);
+	const key = context.registerFieldError.mock.calls[0][0];
+
+	fieldError.setProps({ id: 'new-id' });
+	expect(context.registerFieldError).toHaveBeenCalledTimes(2);
+	expect(context.registerFieldError).toHaveBeenLastCalledWith(key, 'username', 'new-id');
+});
+
 it('should add class isTouched if field is touched', () => {
-	const context = {
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-		isFieldTouched: jest.fn(),
-	};
+	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 	let fieldError = mount(<FieldError name="username" />);
 	expect(fieldError.find('.Jfv_FieldError').hasClass('isTouched')).toBe(false);

--- a/src/lib/FieldError/FieldError.test.js
+++ b/src/lib/FieldError/FieldError.test.js
@@ -121,6 +121,26 @@ it('should allow to override role via props', () => {
 	expect(fieldError.find('.Jfv_FieldError').prop('role')).toBe('status');
 });
 
+it('should have a deterministic id derived from name so fields can reference it', () => {
+	const context = {
+		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
+		isFieldTouched: jest.fn(),
+	};
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const fieldError = mount(<FieldError name="username" />);
+	expect(fieldError.find('.Jfv_FieldError').prop('id')).toBe('jfv-error-username');
+});
+
+it('should allow to override id via props', () => {
+	const context = {
+		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
+		isFieldTouched: jest.fn(),
+	};
+	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
+	const fieldError = mount(<FieldError id="custom-id" name="username" />);
+	expect(fieldError.find('.Jfv_FieldError').prop('id')).toBe('custom-id');
+});
+
 it('should add class isTouched if field is touched', () => {
 	const context = {
 		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),

--- a/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
+++ b/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
@@ -1,18 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should match snapshot 1`] = `
-<FieldError
-  className=""
-  component="div"
-  errorMessages={null}
-  name="username"
->
-  <mockConstructor>
-    <div
-      className="Jfv_FieldError"
-      id="jfv-error-username"
-      role="alert"
-    />
-  </mockConstructor>
-</FieldError>
+<div
+  className="Jfv_FieldError"
+  id="jfv1-error-username"
+  role="alert"
+/>
 `;

--- a/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
+++ b/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
@@ -10,6 +10,7 @@ exports[`should match snapshot 1`] = `
   <mockConstructor>
     <div
       className="Jfv_FieldError"
+      id="jfv-error-username"
       role="alert"
     />
   </mockConstructor>

--- a/src/lib/Form/Context.types.js
+++ b/src/lib/Form/Context.types.js
@@ -64,12 +64,16 @@
  *   touchedFields: string[],
  *   valid: boolean,
  *   errorMessages?: ErrorMessagesMap,
+ *   formId: string,
+ *   getFieldErrorDescribedBy: (name: string) => string | undefined,
  *   getFieldErrors: (names: string | string[]) => FormattedError[],
  *   handleFieldChange: (event: FormChangeEvent | string, value?: unknown) => void,
  *   isFieldTouched: (names: string | string[]) => boolean,
  *   isFieldInvalid: (names: string | string[]) => boolean,
  *   isTouched: () => boolean,
+ *   registerFieldError: (key: string, name: string, id: string) => void,
  *   touch: (names: string | string[]) => void,
+ *   unregisterFieldError: (key: string) => void,
  * }} FormContextValue
  */
 

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -103,6 +103,7 @@ import {
  *
  * @typedef {{
  *   errors: FormattedError[],
+ *   fieldErrorsVersion: number,
  *   isSubmitted: boolean,
  *   touchedFields: string[],
  *   valid: boolean,
@@ -139,9 +140,24 @@ const DEFAULT_DATA = {};
 /** @type {FormState} */
 const initialState = {
 	errors: [],
+	// Bumped whenever the <FieldError> id registry changes, so the memoized
+	// context value is regenerated and consumers (e.g. <Field>'s
+	// aria-describedby) re-render. The registry itself lives on the
+	// instance (`fieldErrorRegistry`), not in state.
+	fieldErrorsVersion: 0,
 	isSubmitted: false,
 	touchedFields: [],
 	valid: true,
+};
+
+// Module-level counter giving each <Form> instance a stable, unique id
+// prefix for its <FieldError> ids (React 16.8 compatible — no useId).
+// Prevents IDREF collisions between two forms holding a field of the same
+// name on the same page.
+let nextFormId = 0;
+const createFormId = () => {
+	nextFormId += 1;
+	return `jfv${nextFormId}`;
 };
 
 /** @extends {PureComponent<FormBaseProps, FormState>} */
@@ -151,6 +167,27 @@ class Form extends PureComponent {
 
 	/** @type {ThrottledValidator | undefined} */
 	throttledValidator;
+
+	/** Unique id of this <Form> instance, exposed through the context. */
+	formId = createFormId();
+
+	/**
+	 * Ordered registry of the <FieldError> descendants: instance key →
+	 * { name, id }. A `Map` preserves insertion order, so the IDREF list
+	 * built by `getFieldErrorDescribedBy` follows mount order
+	 * deterministically. Registration happens in the FieldError lifecycles
+	 * (never during render).
+	 *
+	 * @type {Map<string, { name: string, id: string }>}
+	 */
+	fieldErrorRegistry = new Map();
+
+	/**
+	 * Set while this <Form> unmounts: `unregisterFieldError` becomes a
+	 * no-op so unmounting <FieldError> children do not setState on a
+	 * component being destroyed.
+	 */
+	unmounting = false;
 
 	memoGetClassnames = memoize((
 		/** @type {string | undefined} */ className,
@@ -167,12 +204,16 @@ class Form extends PureComponent {
 	) => ({
 		...state,
 		errorMessages,
+		formId: this.formId,
+		getFieldErrorDescribedBy: this.getFieldErrorDescribedBy,
 		getFieldErrors: this.getFieldErrors,
 		handleFieldChange: this.handleFieldChange,
 		isFieldTouched: this.isFieldTouched,
 		isFieldInvalid: this.isFieldInvalid,
 		isTouched: this.isTouched,
+		registerFieldError: this.registerFieldError,
 		touch: this.touch,
+		unregisterFieldError: this.unregisterFieldError,
 	}))
 
 	memoGetValidator = memoize((
@@ -212,7 +253,65 @@ class Form extends PureComponent {
 	}
 
 	componentWillUnmount() {
+		// Parent willUnmount runs BEFORE the children's: every
+		// unregisterFieldError fired by unmounting <FieldError>s after this
+		// point is a no-op (no setState on a component being destroyed).
+		this.unmounting = true;
 		if (this.throttledValidator) this.throttledValidator.cancel();
+	}
+
+	/**
+	 * Space-separated IDREF list of the registered <FieldError> ids for
+	 * `name` (mount order), or `undefined` when none is registered —
+	 * consumed by <Field> as its default `aria-describedby`.
+	 *
+	 * @param {string} name
+	 * @returns {string | undefined}
+	 */
+	getFieldErrorDescribedBy = (name) => {
+		/** @type {string[]} */
+		const ids = [];
+		this.fieldErrorRegistry.forEach((entry) => {
+			if (entry.name === name) ids.push(entry.id);
+		});
+		const uniqueIds = [...new Set(ids)];
+		return uniqueIds.length ? uniqueIds.join(' ') : undefined;
+	}
+
+	/**
+	 * Registers (or updates) the <FieldError> instance `key` as rendering
+	 * `id` for field `name`. Bails out without setState when the entry is
+	 * already identical (anti-loop guard, paired with the (name, id) guard
+	 * in FieldError.componentDidUpdate). Updating an existing key keeps its
+	 * original position in the Map, so the IDREF order stays the mount
+	 * order.
+	 *
+	 * @param {string} key
+	 * @param {string} name
+	 * @param {string} id
+	 */
+	registerFieldError = (key, name, id) => {
+		const existing = this.fieldErrorRegistry.get(key);
+		if (existing && existing.name === name && existing.id === id) return;
+		this.fieldErrorRegistry.set(key, { name, id });
+		this.setState(({ fieldErrorsVersion }) => ({
+			fieldErrorsVersion: fieldErrorsVersion + 1,
+		}));
+	}
+
+	/**
+	 * Removes the <FieldError> instance `key` from the registry. No-op
+	 * while the whole <Form> unmounts, or when the key is unknown.
+	 *
+	 * @param {string} key
+	 */
+	unregisterFieldError = (key) => {
+		if (this.unmounting) return;
+		if (!this.fieldErrorRegistry.has(key)) return;
+		this.fieldErrorRegistry.delete(key);
+		this.setState(({ fieldErrorsVersion }) => ({
+			fieldErrorsVersion: fieldErrorsVersion + 1,
+		}));
 	}
 
 	getClassnames = () => {

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -245,6 +245,11 @@ class Form extends PureComponent {
 	})
 
 	componentDidMount() {
+		// Reset the flag raised by componentWillUnmount: React 18 StrictMode
+		// (dev) unmounts then REMOUNTS the same instance (cWU then cDM) —
+		// without this reset, unregisterFieldError would stay a no-op
+		// forever and the registry would accumulate stale entries.
+		this.unmounting = false;
 		this.validate();
 	}
 
@@ -272,7 +277,12 @@ class Form extends PureComponent {
 		/** @type {string[]} */
 		const ids = [];
 		this.fieldErrorRegistry.forEach((entry) => {
-			if (entry.name === name) ids.push(entry.id);
+			// A registered <FieldError> may target a wildcard (`user.*`):
+			// reuse the display-side matching so its id is referenced by
+			// every field it covers (literal names still match exactly).
+			if (filterByFieldNameWithWildcard([{ field: name }], entry.name).length) {
+				ids.push(entry.id);
+			}
 		});
 		const uniqueIds = [...new Set(ids)];
 		return uniqueIds.length ? uniqueIds.join(' ') : undefined;

--- a/src/lib/Form/__mocks__/Context.js
+++ b/src/lib/Form/__mocks__/Context.js
@@ -1,11 +1,15 @@
 import React from 'react';
 
 const context = {
+	formId: 'jfv1',
+	getFieldErrorDescribedBy: jest.fn(),
 	getFieldErrors: jest.fn(() => []),
 	handleFieldChange: jest.fn(),
 	isFieldInvalid: jest.fn(),
 	isFieldTouched: jest.fn(),
+	registerFieldError: jest.fn(),
 	touch: jest.fn(),
+	unregisterFieldError: jest.fn(),
 };
 
 const Consumer = jest.fn().mockImplementation((props) => props.children(context));

--- a/src/lib/a11y.js
+++ b/src/lib/a11y.js
@@ -1,0 +1,21 @@
+/**
+ * Accessibility helpers shared by `<Field>` and `<FieldError>`.
+ *
+ * Lives in its own module (not `Form/helpers`) because it carries no form
+ * logic — it only wires the two components together.
+ */
+
+/**
+ * Deterministic id of the `<FieldError>` associated with a field `name`.
+ *
+ * `<Field>` uses it as the default `aria-describedby`, `<FieldError>` as its
+ * default `id`, so the two stay linked without any shared state. `name` may
+ * contain dots or brackets (e.g. `user.emails[0]`): both are valid inside an
+ * HTML id attribute, so the name is used as-is.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+const getFieldErrorId = (name) => `jfv-error-${name}`;
+
+export default getFieldErrorId;

--- a/src/lib/a11y.js
+++ b/src/lib/a11y.js
@@ -6,24 +6,32 @@
  */
 
 /**
- * Deterministic id of the `<FieldError>` associated with a field `name`.
+ * Deterministic default id of a `<FieldError>` for field `name` inside the
+ * `<Form>` instance identified by `formId`.
  *
- * `<Field>` uses it as the default `aria-describedby`, `<FieldError>` as its
- * default `id`, so the two stay linked without any shared state. `name` may
- * contain dots or brackets (e.g. `user.emails[0]`): both are valid inside an
- * HTML id attribute, so the name is used as-is.
+ * The `formId` prefix guarantees that two `<Form>`s rendered on the same
+ * page with a field of the same `name` produce distinct error ids — without
+ * it, an `aria-describedby` IDREF could resolve to the error of the OTHER
+ * form. `name` may contain dots or brackets (e.g. `user.emails[0]`): both
+ * are valid inside an HTML id attribute, so the name is used as-is.
+ *
+ * `<Field>`'s `aria-describedby` does NOT call this function: it reads the
+ * ids actually registered by the mounted `<FieldError>`s from the form
+ * context (see `getFieldErrorDescribedBy`), so a custom `id` prop on
+ * `<FieldError>` stays referenced automatically.
  *
  * Caveats:
- * - Rendering several `<FieldError>` with the same `name` produces duplicate
- *   ids (invalid HTML). Override `id` on all but one of them in that case.
+ * - Rendering several `<FieldError>` with the same `name` in one form
+ *   produces duplicate default ids (invalid HTML). Override `id` on all but
+ *   one of them in that case.
  * - A `name` containing spaces cannot be referenced this way:
  *   `aria-describedby` is a space-separated IDREF list, so the generated id
- *   would be read as several ids. Override both `id` and `aria-describedby`
- *   for such names.
+ *   would be read as several ids. Override `id` for such names.
  *
+ * @param {string} formId
  * @param {string} name
  * @returns {string}
  */
-const getFieldErrorId = (name) => `jfv-error-${name}`;
+const getFieldErrorId = (formId, name) => `${formId}-error-${name}`;
 
 export default getFieldErrorId;

--- a/src/lib/a11y.js
+++ b/src/lib/a11y.js
@@ -13,6 +13,14 @@
  * contain dots or brackets (e.g. `user.emails[0]`): both are valid inside an
  * HTML id attribute, so the name is used as-is.
  *
+ * Caveats:
+ * - Rendering several `<FieldError>` with the same `name` produces duplicate
+ *   ids (invalid HTML). Override `id` on all but one of them in that case.
+ * - A `name` containing spaces cannot be referenced this way:
+ *   `aria-describedby` is a space-separated IDREF list, so the generated id
+ *   would be read as several ids. Override both `id` and `aria-describedby`
+ *   for such names.
+ *
  * @param {string} name
  * @returns {string}
  */

--- a/src/lib/a11y.test.js
+++ b/src/lib/a11y.test.js
@@ -136,6 +136,57 @@ it('should merge a user aria-describedby before the registered error ids', () =>
 	expect(wrapper.find('input').prop('aria-describedby')).toBe(`username-hint ${errorId}`);
 });
 
+it('should reference a wildcard FieldError id from the fields it covers', () => {
+	const nestedSchema = {
+		type: 'object',
+		properties: {
+			user: {
+				type: 'object',
+				properties: {
+					email: { type: 'string' },
+				},
+				required: ['email'],
+			},
+		},
+		required: ['user'],
+	};
+	const wrapper = mount(
+		<Form data={{ user: {} }} onSubmit={() => {}} schema={nestedSchema}>
+			<Field name="user.email" />
+			<FieldError name="user.*" />
+		</Form>,
+	);
+
+	wrapper.find('input').simulate('blur');
+	wrapper.update();
+
+	const errorId = wrapper.find('div.Jfv_FieldError').prop('id');
+	expect(errorId).toMatch(/^jfv\d+-error-user\.\*$/);
+	expect(wrapper.find('input').prop('aria-describedby')).toBe(errorId);
+});
+
+it('should reset the unmounting flag on remount (React 18 StrictMode)', () => {
+	const wrapper = mount(
+		<Form {...formProps}>
+			<FieldError name="username" />
+		</Form>,
+	);
+	const instance = wrapper.instance();
+	expect(instance.fieldErrorRegistry.size).toBe(1);
+	const key = [...instance.fieldErrorRegistry.keys()][0];
+
+	// React 18 StrictMode (dev) unmounts then REMOUNTS the same instance:
+	// componentWillUnmount followed by componentDidMount. Unregistering
+	// must work again after the remount.
+	instance.componentWillUnmount();
+	instance.componentDidMount();
+
+	instance.unregisterFieldError(key);
+	expect(instance.fieldErrorRegistry.size).toBe(0);
+
+	wrapper.unmount();
+});
+
 it('should make unregisterFieldError a no-op while the form unmounts', () => {
 	const wrapper = mount(
 		<Form {...formProps}>

--- a/src/lib/a11y.test.js
+++ b/src/lib/a11y.test.js
@@ -1,0 +1,180 @@
+/**
+ * Integration tests of the Field / FieldError ARIA wiring through a real
+ * <Form> (no context mock): id registry, formId prefixes, IDREF lists.
+ *
+ * The formId module counter increments at each <Form> instance, so these
+ * tests read the id actually rendered by <FieldError> and assert that
+ * <Field> points at it, instead of hardcoding `jfv1` everywhere.
+ */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Form from './Form';
+import Field from './Field';
+import FieldError from './FieldError';
+
+const schema = {
+	type: 'object',
+	properties: {
+		username: { type: 'string' },
+	},
+	required: ['username'],
+};
+
+const formProps = {
+	data: {},
+	onSubmit: () => {},
+	schema,
+};
+
+it('should wire Field aria-describedby to the id rendered by FieldError once touched', () => {
+	const wrapper = mount(
+		<Form {...formProps}>
+			<Field name="username" />
+			<FieldError name="username" />
+		</Form>,
+	);
+
+	wrapper.find('input').simulate('blur');
+	wrapper.update();
+
+	const errorId = wrapper.find('div.Jfv_FieldError').prop('id');
+	expect(errorId).toMatch(/^jfv\d+-error-username$/);
+	expect(wrapper.find('input').prop('aria-describedby')).toBe(errorId);
+	expect(wrapper.find('input').prop('aria-invalid')).toBe(true);
+});
+
+it('should follow a custom FieldError id automatically', () => {
+	const wrapper = mount(
+		<Form {...formProps}>
+			<Field name="username" />
+			<FieldError id="my-custom-error" name="username" />
+		</Form>,
+	);
+
+	wrapper.find('input').simulate('blur');
+	wrapper.update();
+
+	expect(wrapper.find('div.Jfv_FieldError').prop('id')).toBe('my-custom-error');
+	expect(wrapper.find('input').prop('aria-describedby')).toBe('my-custom-error');
+});
+
+it('should keep the error ids of two forms sharing a field name distinct', () => {
+	const wrapper = mount(
+		<div>
+			<Form {...formProps}>
+				<Field name="username" />
+				<FieldError name="username" />
+			</Form>
+			<Form {...formProps}>
+				<Field name="username" />
+				<FieldError name="username" />
+			</Form>
+		</div>,
+	);
+
+	wrapper.find('input').at(0).simulate('blur');
+	wrapper.find('input').at(1).simulate('blur');
+	wrapper.update();
+
+	const ids = wrapper.find('div.Jfv_FieldError').map((node) => node.prop('id'));
+	expect(ids).toHaveLength(2);
+	expect(ids[0]).not.toBe(ids[1]);
+	expect(wrapper.find('input').at(0).prop('aria-describedby')).toBe(ids[0]);
+	expect(wrapper.find('input').at(1).prop('aria-describedby')).toBe(ids[1]);
+});
+
+it('should list every FieldError id of the field in mount order (IDREF list)', () => {
+	const wrapper = mount(
+		<Form {...formProps}>
+			<Field name="username" />
+			<FieldError name="username" />
+			<FieldError id="second-error" name="username" />
+		</Form>,
+	);
+
+	wrapper.find('input').simulate('blur');
+	wrapper.update();
+
+	const firstId = wrapper.find('div.Jfv_FieldError').at(0).prop('id');
+	expect(wrapper.find('input').prop('aria-describedby')).toBe(`${firstId} second-error`);
+});
+
+it('should drop the id of an unmounted FieldError from aria-describedby', () => {
+	const children = [
+		<Field key="field" name="username" />,
+		<FieldError key="first" name="username" />,
+		<FieldError id="second-error" key="second" name="username" />,
+	];
+	const wrapper = mount(<Form {...formProps}>{children}</Form>);
+
+	wrapper.find('input').simulate('blur');
+	wrapper.update();
+
+	const firstId = wrapper.find('div.Jfv_FieldError').at(0).prop('id');
+	expect(wrapper.find('input').prop('aria-describedby')).toBe(`${firstId} second-error`);
+
+	wrapper.setProps({ children: children.slice(0, 2) });
+	wrapper.update();
+	expect(wrapper.find('input').prop('aria-describedby')).toBe(firstId);
+});
+
+it('should merge a user aria-describedby before the registered error ids', () => {
+	const wrapper = mount(
+		<Form {...formProps}>
+			<Field aria-describedby="username-hint" name="username" />
+			<FieldError name="username" />
+		</Form>,
+	);
+
+	expect(wrapper.find('input').prop('aria-describedby')).toBe('username-hint');
+
+	wrapper.find('input').simulate('blur');
+	wrapper.update();
+
+	const errorId = wrapper.find('div.Jfv_FieldError').prop('id');
+	expect(wrapper.find('input').prop('aria-describedby')).toBe(`username-hint ${errorId}`);
+});
+
+it('should make unregisterFieldError a no-op while the form unmounts', () => {
+	const wrapper = mount(
+		<Form {...formProps}>
+			<FieldError name="username" />
+		</Form>,
+	);
+	const instance = wrapper.instance();
+	expect(instance.fieldErrorRegistry.size).toBe(1);
+	const key = [...instance.fieldErrorRegistry.keys()][0];
+
+	// Simulate the unmount sequence: the Form's willUnmount runs first and
+	// raises the flag, then the child FieldError unregisters.
+	instance.componentWillUnmount();
+	const setStateSpy = jest.spyOn(instance, 'setState');
+	instance.unregisterFieldError(key);
+
+	expect(setStateSpy).not.toHaveBeenCalled();
+	expect(instance.fieldErrorRegistry.size).toBe(1);
+
+	setStateSpy.mockRestore();
+	wrapper.unmount();
+});
+
+it('should unmount a whole form silently (unregister no-op while unmounting)', () => {
+	const wrapper = mount(
+		<Form {...formProps}>
+			<Field name="username" />
+			<FieldError name="username" />
+		</Form>,
+	);
+
+	// Without the `unmounting` flag, the unregister fired by the child
+	// FieldError would setState on the Form being destroyed, and React
+	// would report it through console.error.
+	const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+	try {
+		expect(() => wrapper.unmount()).not.toThrow();
+		expect(errorSpy).not.toHaveBeenCalled();
+	} finally {
+		errorSpy.mockRestore();
+	}
+});

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,4 @@
+export { default as getFieldErrorId } from './a11y';
 export { default as Field } from './Field';
 export { default as FieldError } from './FieldError';
 export * from './Form';


### PR DESCRIPTION
## Problem (#57 §1)

Invalid fields expose no programmatic state (`isInvalid` is CSS-only), and the `<FieldError>` message is not associated with its input — screen readers announce neither.

## Design

**Reveal gate** — both ARIA attributes are gated on the same condition as the visual error styling: `isFieldTouched(name) || isSubmitted`. `<FieldError>` is only hidden via CSS before that, and `display:none` elements directly referenced by `aria-describedby` ARE included in the ARIA accessible description; without the gate a pristine form announced "invalid entry" plus the full message on focus.

**Form-scoped id registry** — fixes two defects of the naive deterministic-id approach: cross-form IDREF collisions (two `<Form>`s with a same-named field) and silent desync when a custom `id` is passed to `<FieldError>`.
- Each `<Form>` gets a unique `formId` (`jfv<N>`, module counter — React 16.8 compatible, no `useId`), exposed via context.
- Default `<FieldError>` id: `getFieldErrorId(formId, name)` → `<formId>-error-<name>` (exported from the package entry point).
- `<FieldError>` renders **and registers** its effective id (`props.id ?? default`) in an insertion-ordered Form registry; `<Field>` reads `getFieldErrorDescribedBy(name)` — the space-separated IDREF list in mount order — so custom ids stay referenced automatically, several `<FieldError>`s for one field are all listed, and wildcard `<FieldError name="user.*">` ids are referenced by every field they cover (same matching as error display).
- Registration lives in the FieldError lifecycles via an inner component receiving `form` as a prop (a `withFormContext` wrapper — `static contextType` would break the module mock used by unit tests). The registry entry exists while the component is mounted even when no error is rendered; a dangling IDREF is ignored by AT.

**Ordering guard-rails** (each tested):
1. No registration during render — lifecycles only; the mount-time setState flushes before paint.
2. Anti-loop: `(name, id)` guard in `componentDidUpdate` + identical-entry bail-out in `Form.registerFieldError`.
3. `unmounting` flag on Form: unregister is a no-op during full-form unmount (no setState on a dying component); reset in `componentDidMount` so React 18 StrictMode's unmount/remount of the same instance does not leave it stuck.
4. `Map` insertion order ⇒ deterministic IDREF list in mount order.

**aria-describedby merges, not overrides** (React Aria / Reach UI pattern) — a user-supplied `aria-describedby` (hint text…) is kept FIRST, followed by the registered error ids when revealed: `"pwd-hint jfv1-error-password"`. It is a computed value, so fully disabling the wiring by override is not possible; if ever needed it will be a dedicated prop. `aria-invalid` stays a plain overridable default.

## Breaking changes (vs latest published version)

- `getFieldErrorId` signature is `(formId, name)` — new export, but consumers copying snippets from this PR's earlier iterations must update.
- `FieldError` is now a function component wrapping an internal class: **instance refs to it no longer work** (they resolve to nothing, as for any function component).
- `FieldError` renders a default `id` and `Field` renders `aria-invalid` / `aria-describedby` once touched/submitted: **consumer snapshot tests will churn**.

## Tests

100 total (75 on master): unit suites with mocked context (literal expectations, e.g. `jfv1-error-username`) plus a real-`<Form>` integration suite (`src/lib/a11y.test.js`) covering: custom id followed automatically, two forms with a same-named field get distinct wired ids, IDREF list for two FieldErrors, id dropped on FieldError unmount, wildcard FieldError referenced by covered fields, user-hint merge, unregister no-op while the form unmounts, StrictMode remount reset. Every new/changed behavior verified by anchored mutations (gate forced true, merge→override, registration/unregistration/guards removed, join separator, constant formId, helper string, strict-equality wildcard regression, missing flag reset).