### PR TITLE
build(deps): drop scroll-to-element and lodash.throttle runtime deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,14 +50,11 @@
 		"ajv": "^6.11.0",
 		"classnames": "^2.2.6",
 		"dot-prop-immutable": "^2.1.0",
-		"lodash.throttle": "^4.1.1",
 		"memoize-one": "^5.1.1",
-		"prop-types": "^15.7.2",
-		"scroll-to-element": "^2.0.3"
+		"prop-types": "^15.7.2"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.8.4",
-		"@types/lodash.throttle": "^4.1.9",
 		"@types/prop-types": "^15.7.15",
 		"@types/react": "^16.14.70",
 		"@types/react-dom": "^16.9.25",

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -374,7 +374,12 @@ class Form extends PureComponent {
 		} = scrollOptions || {};
 		// Legacy `offset`, `duration` and `ease` options (scroll-to-element)
 		// are intentionally ignored: the native API has no equivalent.
-		element.scrollIntoView({ behavior, block, inline });
+		// Guard: some environments (e.g. consumers' jsdom test setups) do not
+		// implement scrollIntoView — skip scrolling there, but keep the a11y
+		// focus move below.
+		if (typeof element.scrollIntoView === 'function') {
+			element.scrollIntoView({ behavior, block, inline });
+		}
 		// Move keyboard focus to the first invalid field (a11y). The scroll
 		// itself is handled above, hence `preventScroll`.
 		element.focus({ preventScroll: true });

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -6,19 +6,32 @@
  *   FormHTMLAttributes,
  *   ComponentProps,
  * } from 'react'
- * @import { DebouncedFunc } from 'lodash'
  * @import { JSONSchema7Definition } from 'json-schema'
  * @import { FormattedError, FormChangeEvent, SafePropsOmit } from './helpers'
  * @import { ErrorMessagesMap } from './Context.types'
+ * @import { ThrottledFunc } from './throttle'
  */
 
 /**
  * Options controlling how the form scrolls to the first invalid field on
- * a failed submit.
+ * a failed submit. Forwarded to the native `element.scrollIntoView()`.
+ *
+ * Native `scrollIntoView` options (`behavior`, `block`, `inline`) are passed
+ * through as-is. The legacy `align` option ('top' | 'middle' | 'bottom'),
+ * inherited from the former `scroll-to-element` dependency, is mapped to
+ * `block` ('start' | 'center' | 'end'); an explicit `block` wins over `align`.
+ *
+ * The legacy `offset`, `duration` and `ease` options are still accepted for
+ * backward compatibility but are IGNORED: the native scrolling API has no
+ * equivalent — animation is delegated to the browser via `behavior: 'smooth'`
+ * (the default).
  *
  * @typedef {{
- *   offset?: number,
+ *   behavior?: ScrollBehavior,
+ *   block?: ScrollLogicalPosition,
+ *   inline?: ScrollLogicalPosition,
  *   align?: 'top' | 'middle' | 'bottom' | (string & {}),
+ *   offset?: number,
  *   duration?: number,
  *   ease?: string,
  * }} JfvScrollOptions
@@ -26,13 +39,12 @@
 
 import Ajv from 'ajv';
 import classnames from 'classnames';
-import throttle from 'lodash.throttle';
 import memoize from 'memoize-one';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import scrollToElement from 'scroll-to-element';
 
 import FormContext from './Context';
+import throttle from './throttle';
 import {
 	createAjv,
 	filterByFieldNameWithWildcard,
@@ -110,11 +122,11 @@ import {
  */
 
 /**
- * Return type of `lodash.throttle` applied to the form validator. The
- * `cancel` / `flush` methods (from lodash's `DebouncedFunc<T>` interface)
- * discard pending runs when the schema changes or the component unmounts.
+ * Return type of the local `throttle` helper applied to the form validator.
+ * Its `cancel` method discards pending runs when the schema changes or the
+ * component unmounts.
  *
- * @typedef {DebouncedFunc<(data: object) => void>} ThrottledValidator
+ * @typedef {ThrottledFunc<(data: object) => void>} ThrottledValidator
  */
 
 /**
@@ -135,6 +147,15 @@ const DEFAULT_AJV = createAjv();
 const DEFAULT_THROTTLE_DURATION = 200;
 /** @type {Record<string, unknown>} */
 const DEFAULT_DATA = {};
+
+// Mapping from the legacy `scroll-to-element` `align` option to the native
+// `scrollIntoView` `block` option.
+/** @type {Record<string, ScrollLogicalPosition>} */
+const ALIGN_TO_BLOCK = {
+	top: 'start',
+	middle: 'center',
+	bottom: 'end',
+};
 
 /** @type {FormState} */
 const initialState = {
@@ -345,7 +366,15 @@ class Form extends PureComponent {
 		// No DOM element may carry the error's name (custom field, error on a
 		// nested object): skip scrolling instead of forwarding `undefined`.
 		if (!element) return;
-		scrollToElement(element, scrollOptions);
+		const {
+			align,
+			behavior = 'smooth',
+			block = (align && ALIGN_TO_BLOCK[align]) || 'center',
+			inline = 'nearest',
+		} = scrollOptions || {};
+		// Legacy `offset`, `duration` and `ease` options (scroll-to-element)
+		// are intentionally ignored: the native API has no equivalent.
+		element.scrollIntoView({ behavior, block, inline });
 		// Move keyboard focus to the first invalid field (a11y). The scroll
 		// itself is handled above, hence `preventScroll`.
 		element.focus({ preventScroll: true });
@@ -437,9 +466,8 @@ Form.defaultProps = {
 	onChange: null,
 	scrollToError: true,
 	scrollOptions: {
-		offset: 0,
-		align: 'middle',
-		duration: 900,
+		behavior: 'smooth',
+		block: 'center',
 	},
 	throttleDuration: DEFAULT_THROTTLE_DURATION,
 };

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -17,6 +17,7 @@ const testSchema = {
 // jsdom does not implement Element#scrollIntoView: define a mock so the
 // native scrolling in Form.scrollToFirstError() can run and be asserted on.
 const scrollIntoViewMock = jest.fn();
+const originalScrollIntoView = Element.prototype.scrollIntoView;
 
 beforeAll(() => {
 	Element.prototype.scrollIntoView = scrollIntoViewMock;
@@ -24,6 +25,14 @@ beforeAll(() => {
 
 beforeEach(() => {
 	scrollIntoViewMock.mockClear();
+});
+
+afterAll(() => {
+	if (originalScrollIntoView) {
+		Element.prototype.scrollIntoView = originalScrollIntoView;
+	} else {
+		delete Element.prototype.scrollIntoView;
+	}
 });
 
 it('should match snapshot', () => {
@@ -449,6 +458,46 @@ describe('Form.scrollToFirstError()', () => {
 				block: 'end',
 				inline: 'start',
 			});
+		} finally {
+			wrapper.detach();
+			document.body.removeChild(container);
+		}
+	});
+
+	it('should still move focus without throwing when the element does not implement scrollIntoView', () => {
+		const data = { type: 'invalid-value' };
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={testSchema}
+			>
+				<Field
+					id="test-type"
+					name="type"
+					type="text"
+				/>
+			</Form>,
+			{ attachTo: container },
+		);
+
+		const input = document.getElementById('test-type');
+		// Shadow the prototype mock with an own property: simulates an
+		// environment (e.g. a consumer's jsdom test setup) where
+		// scrollIntoView is not implemented at all.
+		input.scrollIntoView = undefined;
+
+		try {
+			expect(() => {
+				wrapper.find('form').simulate('submit', { preventDefault() {} });
+			}).not.toThrow();
+
+			// Scrolling is skipped, but the a11y focus move still happens.
+			expect(scrollIntoViewMock).not.toHaveBeenCalled();
+			expect(document.activeElement).toBe(input);
 		} finally {
 			wrapper.detach();
 			document.body.removeChild(container);

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -14,6 +14,18 @@ const testSchema = {
 	],
 };
 
+// jsdom does not implement Element#scrollIntoView: define a mock so the
+// native scrolling in Form.scrollToFirstError() can run and be asserted on.
+const scrollIntoViewMock = jest.fn();
+
+beforeAll(() => {
+	Element.prototype.scrollIntoView = scrollIntoViewMock;
+});
+
+beforeEach(() => {
+	scrollIntoViewMock.mockClear();
+});
+
 it('should match snapshot', () => {
 	const wrapper = mount(<Form onSubmit={() => {}} schema={{}} />);
 	expect(wrapper).toMatchSnapshot();
@@ -317,6 +329,126 @@ describe('Form.scrollToFirstError()', () => {
 			wrapper.find('form').simulate('submit', { preventDefault() {} });
 
 			expect(document.activeElement).toBe(document.getElementById('test-type'));
+		} finally {
+			wrapper.detach();
+			document.body.removeChild(container);
+		}
+	});
+
+	it('should scroll the first invalid field into view with smooth/center defaults', () => {
+		const data = { type: 'invalid-value' };
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={testSchema}
+			>
+				<Field
+					id="test-type"
+					name="type"
+					type="text"
+				/>
+			</Form>,
+			{ attachTo: container },
+		);
+
+		try {
+			wrapper.find('form').simulate('submit', { preventDefault() {} });
+
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			expect(scrollIntoViewMock).toHaveBeenCalledWith({
+				behavior: 'smooth',
+				block: 'center',
+				inline: 'nearest',
+			});
+			// The element scrolled into view is the first invalid field.
+			expect(scrollIntoViewMock.mock.instances[0]).toBe(document.getElementById('test-type'));
+		} finally {
+			wrapper.detach();
+			document.body.removeChild(container);
+		}
+	});
+
+	it('should map the legacy align option to block and ignore offset/duration/ease', () => {
+		const data = { type: 'invalid-value' };
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={testSchema}
+				scrollOptions={{
+					align: 'top',
+					offset: 120,
+					duration: 900,
+					ease: 'inOutQuad',
+				}}
+			>
+				<Field
+					id="test-type"
+					name="type"
+					type="text"
+				/>
+			</Form>,
+			{ attachTo: container },
+		);
+
+		try {
+			wrapper.find('form').simulate('submit', { preventDefault() {} });
+
+			// `align: 'top'` maps to `block: 'start'`; the unsupported legacy
+			// options are not forwarded to scrollIntoView.
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			expect(scrollIntoViewMock).toHaveBeenCalledWith({
+				behavior: 'smooth',
+				block: 'start',
+				inline: 'nearest',
+			});
+		} finally {
+			wrapper.detach();
+			document.body.removeChild(container);
+		}
+	});
+
+	it('should forward native scrollIntoView options as-is', () => {
+		const data = { type: 'invalid-value' };
+		const container = document.createElement('div');
+		document.body.appendChild(container);
+
+		const wrapper = mount(
+			<Form
+				data={data}
+				onSubmit={() => {}}
+				schema={testSchema}
+				scrollOptions={{
+					behavior: 'auto',
+					block: 'end',
+					inline: 'start',
+				}}
+			>
+				<Field
+					id="test-type"
+					name="type"
+					type="text"
+				/>
+			</Form>,
+			{ attachTo: container },
+		);
+
+		try {
+			wrapper.find('form').simulate('submit', { preventDefault() {} });
+
+			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+			expect(scrollIntoViewMock).toHaveBeenCalledWith({
+				behavior: 'auto',
+				block: 'end',
+				inline: 'start',
+			});
 		} finally {
 			wrapper.detach();
 			document.body.removeChild(container);

--- a/src/lib/Form/__snapshots__/Form.test.js.snap
+++ b/src/lib/Form/__snapshots__/Form.test.js.snap
@@ -1697,9 +1697,8 @@ exports[`should match snapshot 1`] = `
   schema={Object {}}
   scrollOptions={
     Object {
-      "align": "middle",
-      "duration": 900,
-      "offset": 0,
+      "behavior": "smooth",
+      "block": "center",
     }
   }
   scrollToError={true}

--- a/src/lib/Form/throttle.js
+++ b/src/lib/Form/throttle.js
@@ -1,0 +1,65 @@
+/**
+ * A throttled function, as returned by {@link throttle}. Calling `cancel()`
+ * discards any pending trailing invocation and resets the throttle state.
+ *
+ * @template {(...args: any[]) => void} T
+ * @typedef {T & { cancel: () => void }} ThrottledFunc
+ */
+
+/**
+ * Minimal local replacement for the deprecated `lodash.throttle` per-method
+ * package, reproducing the lodash semantics this library relies on:
+ * - leading edge: the first call in a quiet period invokes `func` immediately;
+ * - trailing edge: calls made during the `wait` window are coalesced into a
+ *   single invocation (with the latest arguments) at the end of the window;
+ * - `cancel()`: drops any pending trailing invocation.
+ *
+ * @template {(...args: any[]) => void} T
+ * @param {T} func The function to throttle.
+ * @param {number} [wait] The number of milliseconds to throttle invocations to.
+ * @returns {ThrottledFunc<T>} The throttled function.
+ */
+const throttle = (func, wait = 0) => {
+	/** @type {ReturnType<typeof setTimeout> | null} */
+	let timeout = null;
+	/** @type {Parameters<T> | null} */
+	let pendingArgs = null;
+	let lastInvokeTime = 0;
+
+	/** @param {Parameters<T>} args */
+	const invoke = (args) => {
+		lastInvokeTime = Date.now();
+		func(...args);
+	};
+
+	/** @param {Parameters<T>} args */
+	const throttled = (...args) => {
+		const remaining = wait - (Date.now() - lastInvokeTime);
+		if (remaining <= 0 && !timeout) {
+			invoke(args);
+			return;
+		}
+		pendingArgs = args;
+		if (!timeout) {
+			timeout = setTimeout(() => {
+				timeout = null;
+				if (pendingArgs) {
+					const args2 = pendingArgs;
+					pendingArgs = null;
+					invoke(args2);
+				}
+			}, Math.max(remaining, 0));
+		}
+	};
+
+	throttled.cancel = () => {
+		if (timeout) clearTimeout(timeout);
+		timeout = null;
+		pendingArgs = null;
+		lastInvokeTime = 0;
+	};
+
+	return /** @type {ThrottledFunc<T>} */ (throttled);
+};
+
+export default throttle;

--- a/src/lib/Form/throttle.test.js
+++ b/src/lib/Form/throttle.test.js
@@ -1,0 +1,80 @@
+import throttle from './throttle';
+
+describe('throttle(func, wait)', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('should invoke immediately on the leading edge', () => {
+		const func = jest.fn();
+		const throttled = throttle(func, 200);
+
+		throttled('first');
+
+		expect(func).toHaveBeenCalledTimes(1);
+		expect(func).toHaveBeenCalledWith('first');
+	});
+
+	it('should coalesce calls made during the wait window into one trailing call with the latest arguments', () => {
+		const func = jest.fn();
+		const throttled = throttle(func, 200);
+
+		throttled('a');
+		throttled('b');
+		throttled('c');
+
+		// Only the leading call has run so far.
+		expect(func).toHaveBeenCalledTimes(1);
+		expect(func).toHaveBeenCalledWith('a');
+
+		jest.advanceTimersByTime(200);
+
+		// The two coalesced calls produced a single trailing invocation,
+		// carrying the most recent arguments.
+		expect(func).toHaveBeenCalledTimes(2);
+		expect(func).toHaveBeenLastCalledWith('c');
+	});
+
+	it('should not invoke a trailing call when no call happened during the wait window', () => {
+		const func = jest.fn();
+		const throttled = throttle(func, 200);
+
+		throttled('only');
+		jest.advanceTimersByTime(1000);
+
+		expect(func).toHaveBeenCalledTimes(1);
+	});
+
+	it('cancel() should discard the pending trailing invocation', () => {
+		const func = jest.fn();
+		const throttled = throttle(func, 200);
+
+		throttled('a');
+		throttled('b');
+		expect(func).toHaveBeenCalledTimes(1);
+
+		throttled.cancel();
+		jest.advanceTimersByTime(1000);
+
+		// The pending trailing call for 'b' never fires.
+		expect(func).toHaveBeenCalledTimes(1);
+	});
+
+	it('should allow a new leading invocation after cancel()', () => {
+		const func = jest.fn();
+		const throttled = throttle(func, 200);
+
+		throttled('a');
+		throttled('b');
+		throttled.cancel();
+
+		throttled('c');
+
+		expect(func).toHaveBeenCalledTimes(2);
+		expect(func).toHaveBeenLastCalledWith('c');
+	});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,18 +1556,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/lodash.throttle@^4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.9.tgz#f17a6ae084f7c0117bd7df145b379537bc9615c5"
-  integrity sha512-PCPVfpfueguWZQB7pJQK890F2scYKoDUL3iM522AptHWn7d5NQmeS/LTEHIcLr5PaTzl3dK2Z0xSUHHTHwaL5g==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.17.24"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.24.tgz#4ae334fc62c0e915ca8ed8e35dcc6d4eeb29215f"
-  integrity sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -7060,11 +7048,6 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
-
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -9183,7 +9166,7 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
-raf@^3.4.0, raf@^3.4.1:
+raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -10032,13 +10015,6 @@ schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6
   dependencies:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
-
-scroll-to-element@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/scroll-to-element/-/scroll-to-element-2.0.3.tgz#99b404fc6a09fe73f3c062cd5b8a14efb6404e4d"
-  integrity sha512-5herPcm9jMfQgRwu94lH5mei+2YhipR4RQ2nAvnBxJb2tG+P7O0ctOKAaAZBXbBejnn+MImh3wrAUA5EcLnjEQ==
-  dependencies:
-    raf "^3.4.0"
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Part of #57 (§3) — removes two dead runtime dependencies.

## Changes

- **`scroll-to-element` → native `element.scrollIntoView()`** — the package has been unmaintained since ~2018. `scrollToFirstError` keeps its guards and the `focus({ preventScroll: true })` call from #61. Legacy `align` (`top`/`middle`/`bottom`) is mapped to `block` (`start`/`center`/`end`); native `{ behavior, block, inline }` options are also accepted and forwarded as-is. Defaults: `behavior: 'smooth'`, `block: 'center'`, `inline: 'nearest'`. The call is guarded by `typeof element.scrollIntoView === 'function'`: environments that do not implement it (e.g. consumers' jsdom test setups) skip scrolling without throwing, and the a11y focus move still runs.
- **`lodash.throttle` → local `src/lib/Form/throttle.js`** — the per-method lodash packages are deprecated. Minimal implementation reproducing the semantics the form relies on: leading + trailing edges, coalesced calls, `cancel()` (used by `componentWillUnmount` and `memoGetValidator`). Dedicated fake-timer tests. The `DebouncedFunc` JSDoc type from lodash is replaced by the local `ThrottledFunc`.
- **package.json** — removed `scroll-to-element`, `lodash.throttle` (dependencies) and `@types/lodash.throttle` (devDependencies); `yarn.lock` updated.

## Semi-breaking (targets 0.7.0)

- The legacy `scrollOptions` `offset`, `duration` and `ease` are still accepted but **ignored**: the native API has no equivalent — scroll animation is delegated to the browser via `behavior: 'smooth'`. Custom animation duration/easing is lost. Documented in the `JfvScrollOptions` JSDoc. 0.7.0 is already required by the peerDeps narrowing of #59.
- **Safari < 15.4**: `scrollIntoView` ignores the options object there (treated as `scrollIntoView(truthy)`), resulting in an instant scroll aligned to top instead of a smooth centered scroll. Graceful degradation, no crash.

## Tests

- jsdom does not implement `scrollIntoView`: tests mock it on `Element.prototype` (restored in `afterAll`) and assert the exact options object passed (defaults, legacy `align` mapping with ignored extras, native passthrough), plus a test proving that an element without `scrollIntoView` does not throw and still receives focus.
- Suite: 6 suites / 75 tests / 5 snapshots on master → 7 / 84 / 5 here, all green (`CI=true yarn test:runtime`); `yarn type-check` clean. Snapshot updated for the new `scrollOptions` default only.
- Every new test was mutation-checked (leading edge, coalescing, spurious trailing, cancel, align mapping, option forwarding, element lookup, scrollIntoView guard): each mutation failed the intended assertions for the right reason.