### PR TITLE
build(npm): modern exports map, sideEffects: false, engines.node (issue #57 §4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
 		"./dist/react-jsonschema-form-validation.css": "./dist/react-jsonschema-form-validation.css",
 		"./dist/react-jsonschema-form-validation.min.css": "./dist/react-jsonschema-form-validation.min.css"
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"*.css"
+	],
 	"engines": {
 		"node": ">=20"
 	},

--- a/package.json
+++ b/package.json
@@ -35,6 +35,19 @@
 	"main": "dist/index.js",
 	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./package.json": "./package.json",
+		"./dist/react-jsonschema-form-validation.css": "./dist/react-jsonschema-form-validation.css",
+		"./dist/react-jsonschema-form-validation.min.css": "./dist/react-jsonschema-form-validation.min.css"
+	},
+	"sideEffects": false,
+	"engines": {
+		"node": ">=20"
+	},
 	"files": [
 		"dist",
 		"README.md"


### PR DESCRIPTION
## What

Packaging-only PR (issue #57, §4). Touches **package.json only** — no source, no README, no build changes.

## What was wrong

`main` and `module` both point to `dist/index.js`. Inspecting the actual `yarn dist` output shows the Babel build (preset `react-app`, `modules: false`) emits **ESM syntax** in `.js` files — so `module` is in fact truthful, and it is `main` that over-promises: Node cannot `require()` (nor even `import`) the package directly, because the output keeps extensionless internal specifiers (`export ... from './a11y'`). The package is de facto **bundler-only**, and has been all along.

## Changes

- **`exports` map** consistent with the real single-format build:
  - `"."` → `types: dist/index.d.ts`, `default: dist/index.js`
  - `"./package.json"`
  - `"./dist/react-jsonschema-form-validation.css"` and `.min.css` (the two stylesheets actually produced by `yarn dist`)
  - `main`/`module`/`types` kept for resolvers that predate `exports` (webpack 4 etc.).
- **`sideEffects: ["*.css"]`** — every module in `src/lib` is side-effect-free at import time (no CSS imports from JS, no polyfills, only pure top-level declarations; the single `document.*` usage is inside a runtime submit handler in `Form.js`), so the JS stays fully tree-shakeable. The CSS files must stay listed as side-effectful: a side-effect-only `import '.../dist/react-jsonschema-form-validation.css'` would otherwise be pruned entirely by webpack production builds or Rollup + node-resolve (see [webpack docs on `sideEffects`](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)). Verified empirically — see Validation.
- **`engines.node: ">=20"`** — aligned with `.nvmrc` (`20`), which CI uses via `node-version-file`.

## Release note (0.7.0)

> **Packaging changes — may affect non-standard consumers.**
> - The package now declares an `exports` map. Only the root entry (`react-jsonschema-form-validation`), `./package.json`, and the two stylesheets (`./dist/react-jsonschema-form-validation.css`, `./dist/react-jsonschema-form-validation.min.css`) are public. **Deep imports of any other internal path (e.g. `react-jsonschema-form-validation/dist/Form/Form.js`) now fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`** — import from the root entry instead.
> - The package now declares `sideEffects: ["*.css"]`: bundlers may tree-shake unused JS exports; CSS imports are preserved. If you relied on importing internal files for unexported helpers, that is no longer supported.
> - `engines.node >= 20` is now declared (npm warns on older Node at install time).

(The README line documenting the packaged CSS import belongs to the docs PR #69, not here.)

## Validation

- `yarn dist` passes; `npm pack --dry-run` lists 19 files (LICENSE auto-included, README, full `dist/`, package.json) — nothing missing, nothing extra.
- Local install of the packed tarball in a scratch project:
  - `require.resolve` OK for root entry, `./package.json`, both CSS subpaths; internal deep path correctly rejected with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
  - webpack 4 bundles the installed package (via `module` field) and the bundle executes: `Form`/`Field`/`FieldError` exports intact. webpack 5 / Vite resolve through `exports` to the same file.
  - **`sideEffects` A/B proof** (webpack 4, `mode: production`, css-loader + mini-css-extract-plugin, entry doing a side-effect-only import of the packaged CSS plus a JS import): with `"sideEffects": false` the CSS module is pruned — only `bundle.js` is emitted; with `["*.css"]` the extracted `styles.css` (277 B) is emitted alongside `bundle.js`.
  - Node `require()`/`import()` fail identically **before and after** this PR (extensionless ESM imports in the Babel output) — pre-existing, not a regression.
- `CI=true yarn test:runtime`: 8 suites, 109 tests, 5 snapshots — all green.

## Follow-up (out of scope)

A real dual ESM/CJS build (proper `import`/`require` conditions, extension-full output or `type: module`) would make the package consumable from plain Node. That is a build-pipeline change and deliberately excluded from this PR.