### PR TITLE
docs: accessibility & useFormContext sections; drop stale CircleCI refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,128 @@ class DemoForm extends PureComponent {
 
 🎵 _That's all folks !_ 
 
+## Accessibility
+
+`<Field>` and `<FieldError>` wire the essential ARIA attributes for you — no
+extra props needed:
+
+- `<FieldError>` renders with `role="alert"` by default, so assistive
+  technologies announce the message as soon as it appears. Pass your own
+  `role` prop to override it.
+- `<Field>` sets `aria-invalid="true"` on the rendered element when the field
+  is invalid **and** revealed (touched, or the form was submitted) — the same
+  condition as the visual error styling, so nothing is announced on a
+  pristine form. It is a plain default: an explicit `aria-invalid` prop wins.
+- `aria-describedby` is wired automatically: each `<FieldError>` registers its
+  `id` in the parent `<Form>`, and the matching `<Field>` references those ids
+  once the field is revealed. The default id is deterministic —
+  `jfv<N>-error-<name>`, where `jfv<N>` identifies the `<Form>` instance so
+  two forms on the same page never collide. A custom `id` prop on
+  `<FieldError>` is followed automatically.
+- An `aria-describedby` you pass to `<Field>` yourself is **merged**, not
+  replaced: your ids come first (e.g. a hint text), the error ids after.
+- On a failed submit, keyboard focus moves to the first invalid field
+  (disable with `scrollToError={false}` on `<Form>`).
+
+```jsx
+<span id="email-hint">We never share your email.</span>
+<Field name="email" aria-describedby="email-hint" value={formData.email} />
+<FieldError name="email" />
+{/* Once the field is touched (or the form submitted) and invalid,
+    the input renders:
+    aria-invalid="true" aria-describedby="email-hint jfv1-error-email" */}
+```
+
+The default error id can be computed with the exported helper (`formId` is
+available on the form context, see [useFormContext](#reading-the-form-state-useformcontext)):
+
+```js
+import { getFieldErrorId } from 'react-jsonschema-form-validation';
+
+getFieldErrorId('jfv1', 'email'); // 'jfv1-error-email'
+```
+
+Known limitations:
+
+- Rendering several `<FieldError>` with the same `name` in one form produces
+  duplicate default ids (invalid HTML). Override `id` on all but one of them.
+- A `name` containing spaces cannot be referenced through the generated
+  `aria-describedby` (it is a space-separated id list). Give such a
+  `<FieldError>` a custom `id`.
+
+## Reading the form state: useFormContext
+
+Everything `<Form>` knows is available to its descendants through the
+`useFormContext()` hook (a legacy render-prop helper, `withFormContext(cb)`,
+also exists). Both throw a descriptive error when used outside a `<Form>`.
+
+```js
+import { useFormContext } from 'react-jsonschema-form-validation';
+```
+
+Main context values:
+
+| Name | Description |
+| --- | --- |
+| `errors` | Current validation errors (`FormattedError[]`, each with a normalized `field` path) |
+| `valid` | `true` when the data matches the schema |
+| `isSubmitted` | `true` once a submit has been attempted |
+| `touchedFields` | Names of the fields that have been blurred |
+| `getFieldErrors(names)` | Errors for one or several field paths (wildcards like `emails.*` work) |
+| `isFieldInvalid(names)` | `true` if any of the given fields has an error |
+| `isFieldTouched(names)` | `true` if any of the given fields was touched |
+| `isTouched()` | `true` if at least one field was touched |
+| `touch(names)` | Marks fields as touched |
+| `handleFieldChange(event)` or `handleFieldChange(name, value)` | Applies a change programmatically |
+| `formId` | Unique id of the `<Form>` instance (see [Accessibility](#accessibility)) |
+| `errorMessages` | The `errorMessages` map passed to `<Form>`, if any |
+
+(The remaining values — `getFieldErrorDescribedBy`, `registerFieldError`,
+`unregisterFieldError` — are internal wiring between `<Field>` and
+`<FieldError>`.)
+
+**Disable the submit button while the form is invalid:**
+
+```jsx
+const SubmitButton = ({ children }) => {
+	const { valid } = useFormContext();
+	return (
+		<button type="submit" disabled={!valid}>
+			{children}
+		</button>
+	);
+};
+```
+
+**Show an error summary after a failed submit:**
+
+```jsx
+const ErrorSummary = () => {
+	const { errors, isSubmitted } = useFormContext();
+	if (!isSubmitted || !errors.length) return null;
+	return (
+		<ul>
+			{errors.map((error) => (
+				<li key={`${error.field}-${error.keyword}`}>
+					{`${error.field}: ${error.message}`}
+				</li>
+			))}
+		</ul>
+	);
+};
+```
+
+Use them anywhere inside the `<Form>`:
+
+```jsx
+<Form data={formData} onChange={handleChange} onSubmit={handleSubmit} schema={demoSchema}>
+	<ErrorSummary />
+	<Field name="email" value={formData.email} />
+	<FieldError name="email" />
+	<SubmitButton>Submit</SubmitButton>
+</Form>
+```
+
 ## TypeScript
 
 The library is fully typed — `.d.ts` declarations ship with the package, no

--- a/README.md
+++ b/README.md
@@ -213,8 +213,9 @@ Main context values:
 | --- | --- |
 | `errors` | Current validation errors (`FormattedError[]`, each with a normalized `field` path) |
 | `valid` | `true` when the data matches the schema. Validation is throttled (200 ms by default, `throttleDuration` prop on `<Form>`), so `valid` can lag one beat behind the latest change |
-| `isSubmitted` | `true` once a submit has been attempted (reset after a successful submit) |
+| `isSubmitted` | `true` once a submit has been attempted (reset after a successful submit, unless `resetOnSubmit={false}`) |
 | `touchedFields` | Names of the fields that have been blurred |
+| `reset()` | Resets `errors`, `touchedFields` and `isSubmitted` to their initial state (called automatically after a successful submit unless `resetOnSubmit={false}`) |
 | `getFieldErrors(names)` | Errors for one or several field paths (wildcards like `emails.*` work) |
 | `isFieldInvalid(names)` | `true` if any of the given fields has an error |
 | `isFieldTouched(names)` | `true` if any of the given fields was touched |

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ npm install react-jsonschema-form-validation
 yarn add react-jsonschema-form-validation
 ```
 
+Then import the packaged stylesheet — the minimal CSS mentioned above (a red
+color for error messages, easily overridden):
+
+```js
+import 'react-jsonschema-form-validation/dist/react-jsonschema-form-validation.css';
+```
+
+A minified variant is also shipped:
+`react-jsonschema-form-validation/dist/react-jsonschema-form-validation.min.css`.
+
 ## Getting started
 
 Import modules:  
@@ -202,8 +212,8 @@ Main context values:
 | Name | Description |
 | --- | --- |
 | `errors` | Current validation errors (`FormattedError[]`, each with a normalized `field` path) |
-| `valid` | `true` when the data matches the schema |
-| `isSubmitted` | `true` once a submit has been attempted |
+| `valid` | `true` when the data matches the schema. Validation is throttled (200 ms by default, `throttleDuration` prop on `<Form>`), so `valid` can lag one beat behind the latest change |
+| `isSubmitted` | `true` once a submit has been attempted (reset after a successful submit) |
 | `touchedFields` | Names of the fields that have been blurred |
 | `getFieldErrors(names)` | Errors for one or several field paths (wildcards like `emails.*` work) |
 | `isFieldInvalid(names)` | `true` if any of the given fields has an error |
@@ -214,9 +224,9 @@ Main context values:
 | `formId` | Unique id of the `<Form>` instance (see [Accessibility](#accessibility)) |
 | `errorMessages` | The `errorMessages` map passed to `<Form>`, if any |
 
-(The remaining values — `getFieldErrorDescribedBy`, `registerFieldError`,
-`unregisterFieldError` — are internal wiring between `<Field>` and
-`<FieldError>`.)
+(The remaining values — `fieldErrorsVersion`, `getFieldErrorDescribedBy`,
+`registerFieldError`, `unregisterFieldError` — are internal wiring between
+`<Field>` and `<FieldError>`.)
 
 **Disable the submit button while the form is invalid:**
 

--- a/test-types/README.md
+++ b/test-types/README.md
@@ -32,12 +32,13 @@ local, `.github/workflows/ci.yml` for CI matrix).
 
 ```bash
 # From repo root
-yarn test:types    # ~10s, checks the bundle against @types/react 16 + 17 + 18
+yarn test:types    # checks the bundle against @types/react 16 + 17 + 18 + 19
 yarn test          # unit tests + type tests
 ```
 
 ## CI
 
-Each `@types/react` version runs as a **separate CircleCI matrix job**
-(`types-16`, `types-17`, `types-18`) — parallel, no shell mutation,
-extends in one line if a new major lands.
+Each `@types/react` version runs as a **separate GitHub Actions job** through
+the `types` matrix in `.github/workflows/ci.yml` (`types (@types/react 16)` …
+`types (@types/react 19)`) — parallel, no shell mutation, extends in one line
+if a new major lands.

--- a/test-types/check-matrix.sh
+++ b/test-types/check-matrix.sh
@@ -3,8 +3,8 @@
 # @types/react major, then restores the default (16) — even on failure or
 # Ctrl-C, thanks to the trap on EXIT.
 #
-# CI runs the equivalent via CircleCI matrix jobs (see .circleci/config.yml)
-# and does NOT rely on this script.
+# CI runs the equivalent via the GitHub Actions `types` matrix (see
+# .github/workflows/ci.yml) and does NOT rely on this script.
 
 set -euo pipefail
 cd "$(dirname "$0")"


### PR DESCRIPTION
## Summary

Documentation-only PR (issue #57 §5/§6 follow-ups). No source or config change.

- **README — Accessibility (new section)**: documents the automatic ARIA wiring shipped in #59/#65 — `role="alert"` default on `<FieldError>` (overridable), `aria-invalid` gated on touched/submitted on `<Field>`, auto-merged `aria-describedby` through the per-form id registry (`jfv<N>-error-<name>`, user IDREFs first), the exported `getFieldErrorId(formId, name)` helper, focus-on-first-error on failed submit, and the two known limitations (duplicate default ids for same-name `<FieldError>`s, names containing spaces).
- **README — useFormContext (new section)**: the hook was exported but undocumented. Lists the context values actually exposed by `<Form>` (`errors`, `valid`, `isSubmitted`, `touchedFields`, `getFieldErrors`, `isFieldInvalid`, `isFieldTouched`, `isTouched`, `touch`, `handleFieldChange`, `formId`, `errorMessages`) and two examples: submit button disabled while invalid, error summary after a failed submit. Legacy `withFormContext` mentioned.
- **test-types**: purge of stale CircleCI references (CI is GitHub Actions since #54) — comment-only header fix in `check-matrix.sh` (logic untouched, `bash -n` clean) and CI section of `test-types/README.md` now points to the `types` matrix in `.github/workflows/ci.yml` (@types/react 16-19; local run note updated to include 19).

## Verification

- Every documented name was checked against `src/lib` (`index.js`, `Form/Context.js`, `Form/Context.types.js`, `Form/Form.js`, `Field/Field.js`, `FieldError/FieldError.js`). `reset` is deliberately not documented — it is not part of the context value.
- Both README examples were reproduced verbatim in a throwaway jest run (outside the repo) against the worktree lib: button disabled/enabled, summary shown after failed submit, `aria-invalid` gating, merged `aria-describedby` (`email-hint jfv<N>-error-email`), `role="alert"`, `getFieldErrorId` output — all green.
- `bash -n test-types/check-matrix.sh`: OK.
- `CI=true yarn test:runtime`: 8 suites / 109 tests passed.

Refs #57