### PR TITLE
test: migrate test suite from Jest/Enzyme to Vitest + React Testing Library

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,24 @@ module.exports = {
 			files: ['vite.config.js', 'vitest.config.js'],
 			rules: {
 				'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
+				// `vitest/config` is an `exports` subpath; the node resolver
+				// bundled with eslint-plugin-import 2.20 predates package
+				// exports and cannot see it.
+				'import/no-unresolved': ['error', { ignore: ['^vitest/config$'] }],
+			},
+		},
+		{
+			// Vitest injects its globals (`globals: true` in vitest.config.js).
+			// eslint-plugin-vitest would declare them but requires ESLint 8;
+			// declare the ones not already covered by the jest plugin env.
+			files: ['src/**/*.test.js', 'src/**/__mocks__/*.js', 'src/setupTests.js'],
+			globals: {
+				vi: 'readonly',
+			},
+			rules: {
+				// Test setup files import test-only packages (vitest), like
+				// the *.test.js files already allowed by the base config.
+				'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
 			},
 		},
 	],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: yarn
-      - run: yarn install --frozen-lockfile --ignore-optional
+      - run: yarn install --frozen-lockfile
       - run: yarn type-check
       - run: yarn test:runtime
       - run: yarn dist
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: yarn
-      - run: yarn install --frozen-lockfile --ignore-optional
+      - run: yarn install --frozen-lockfile
       - run: yarn dist:js && yarn dist:types
       - run: bash test-types/setup.sh
       - name: Type-check against @types/react@^${{ matrix.types-react }}

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
 		"dist:types:cleanup": "rm -rf .types-temp",
 		"minify:css": "cleancss --level 1 --source-map --source-map-inline-sources --output dist/$npm_package_name.min.css dist/$npm_package_name.css",
 		"test": "npm-run-all --sequential test:runtime test:types",
-		"test:runtime": "react-scripts test --watchAll=false",
-		"test:runtime:watch": "react-scripts test",
+		"test:runtime": "vitest run",
+		"test:runtime:watch": "vitest",
 		"test:types": "bash test-types/check-matrix.sh",
 		"type-check": "tsc -p tsconfig.json",
 		"eject": "react-scripts eject",
-		"prepublishOnly": "yarn test:runtime --ci --bail --runInBand && yarn test:types && yarn dist",
+		"prepublishOnly": "yarn test:runtime --bail 1 && yarn test:types && yarn dist",
 		"preversion": "npm run docs && git add docs && (git commit -m \"update docs for new version\" || echo \"No changes to commit\")"
 	},
 	"browserslist": [
@@ -70,10 +70,12 @@
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.8.4",
+		"@testing-library/react": "^12.1.5",
 		"@types/prop-types": "^15.7.15",
 		"@types/react": "^16.14.70",
 		"@types/react-dom": "^16.9.25",
 		"@vitejs/plugin-react": "^4.3.0",
+		"@vitest/coverage-istanbul": "^2.1.9",
 		"babel-eslint": "10.0.3",
 		"bootstrap": "^4.4.1",
 		"clean-css-cli": "^4.3.0",
@@ -88,7 +90,9 @@
 		"eslint-plugin-import": "2.20.1",
 		"eslint-plugin-jest": "^23.6.0",
 		"eslint-plugin-react": "7.18.3",
+		"istanbul-lib-coverage": "^3.2.2",
 		"jest": "24.9.0",
+		"jsdom": "^25.0.1",
 		"npm-run-all": "^4.1.5",
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0",
@@ -100,27 +104,14 @@
 		"reactstrap": "^8.4.1",
 		"sass": "^1.101.7",
 		"typescript": "^6.0.3",
-		"vite": "^5.4.0"
+		"vite": "^5.4.0",
+		"vitest": "^2.1.9"
 	},
 	"peerDependencies": {
 		"react": ">=16.8"
 	},
 	"resolutions": {
 		"dts-bundle-generator/typescript": "^6.0.3"
-	},
-	"jest": {
-		"collectCoverageFrom": [
-			"src/lib/**/*.{js,jsx,ts,tsx}"
-		],
-		"watchPathIgnorePatterns": [
-			"/build/",
-			"/dist/",
-			"/docs/",
-			"/node_modules/"
-		],
-		"snapshotSerializers": [
-			"enzyme-to-json/serializer"
-		]
 	},
 	"keywords": [
 		"JSON",

--- a/src/lib/Field/Field.test.js
+++ b/src/lib/Field/Field.test.js
@@ -1,241 +1,245 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 
 import FormContext from '../Form/Context';
 import Field from './Field';
 
-jest.mock('../Form/Context');
+vi.mock('../Form/Context');
 
 it('should match snapshot', () => {
-	const field = mount(<Field name="username" />);
-	expect(field).toMatchSnapshot();
+	const { container } = render(<Field name="username" />);
+	expect(container.firstChild).toMatchSnapshot();
 });
 
 it('should call form.touch when blurred', () => {
 	const context = {
-		getFieldErrors: jest.fn(() => []),
-		handleFieldChange: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
-		touch: jest.fn(),
+		getFieldErrors: vi.fn(() => []),
+		handleFieldChange: vi.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
+		touch: vi.fn(),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field name="username" />);
-	field.find('input').simulate('blur');
+	const { container } = render(<Field name="username" />);
+	fireEvent.blur(container.querySelector('input'));
 	expect(context.touch).toHaveBeenCalled();
 });
 
 it('should call onBlur handler when blurred', () => {
-	const onBlur = jest.fn();
-	const field = mount(<Field name="username" onBlur={onBlur} />);
-	field.find('input').simulate('blur');
+	const onBlur = vi.fn();
+	const { container } = render(<Field name="username" onBlur={onBlur} />);
+	fireEvent.blur(container.querySelector('input'));
 	expect(onBlur).toHaveBeenCalled();
 });
 
 it('should add class isSubmitted if form is submitted', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		getFieldErrorDescribedBy: vi.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 
-	let field = mount(<Field name="username" />);
-	expect(field.find('.Jfv_Field').hasClass('isSubmitted')).toBe(false);
+	let { container } = render(<Field name="username" />);
+	expect(container.querySelector('.Jfv_Field').classList.contains('isSubmitted')).toBe(false);
 
 	context.isSubmitted = true;
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	field = mount(<Field name="username" />);
-	expect(field.find('.Jfv_Field').hasClass('isSubmitted')).toBe(true);
+	({ container } = render(<Field name="username" />));
+	expect(container.querySelector('.Jfv_Field').classList.contains('isSubmitted')).toBe(true);
 });
 
 it('should add class isTouched if field is touched', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		getFieldErrorDescribedBy: vi.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 
-	let field = mount(<Field name="username" />);
-	expect(field.find('.Jfv_Field').hasClass('isTouched')).toBe(false);
+	let { container } = render(<Field name="username" />);
+	expect(container.querySelector('.Jfv_Field').classList.contains('isTouched')).toBe(false);
 
 	context.isFieldTouched.mockImplementation(() => true);
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	field = mount(<Field name="username" />);
-	expect(field.find('.Jfv_Field').hasClass('isTouched')).toBe(true);
+	({ container } = render(<Field name="username" />));
+	expect(container.querySelector('.Jfv_Field').classList.contains('isTouched')).toBe(true);
 });
 
 it('should add class isInvalid if field is invalid', () => {
 	const context = {
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 
-	let field = mount(<Field name="username" />);
-	expect(field.find('.Jfv_Field').hasClass('isInvalid')).toBe(false);
+	let { container } = render(<Field name="username" />);
+	expect(container.querySelector('.Jfv_Field').classList.contains('isInvalid')).toBe(false);
 
 	context.isFieldInvalid.mockImplementation(() => true);
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	field = mount(<Field name="username" />);
-	expect(field.find('.Jfv_Field').hasClass('isInvalid')).toBe(true);
+	({ container } = render(<Field name="username" />));
+	expect(container.querySelector('.Jfv_Field').classList.contains('isInvalid')).toBe(true);
 });
 
 it('should not expose aria-invalid nor aria-describedby while untouched and unsubmitted, even if invalid', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
-		isFieldInvalid: jest.fn(() => true),
-		isFieldTouched: jest.fn(() => false),
+		getFieldErrorDescribedBy: vi.fn(() => 'jfv1-error-username'),
+		isFieldInvalid: vi.fn(() => true),
+		isFieldTouched: vi.fn(() => false),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field name="username" />);
-	expect(field.find('input').prop('aria-invalid')).toBe(undefined);
-	expect(field.find('input').getDOMNode().hasAttribute('aria-invalid')).toBe(false);
-	expect(field.find('input').prop('aria-describedby')).toBe(undefined);
-	expect(field.find('input').getDOMNode().hasAttribute('aria-describedby')).toBe(false);
+	const { container } = render(<Field name="username" />);
+	// A React `aria-invalid={undefined}` prop renders no attribute at all.
+	const input = container.querySelector('input');
+	expect(input.hasAttribute('aria-invalid')).toBe(false);
+	expect(input.hasAttribute('aria-describedby')).toBe(false);
 	expect(context.getFieldErrorDescribedBy).not.toHaveBeenCalled();
 });
 
 it('should set aria-invalid when the field is invalid and touched', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(),
-		isFieldInvalid: jest.fn(() => true),
-		isFieldTouched: jest.fn(() => true),
+		getFieldErrorDescribedBy: vi.fn(),
+		isFieldInvalid: vi.fn(() => true),
+		isFieldTouched: vi.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field name="username" />);
-	expect(field.find('input').prop('aria-invalid')).toBe(true);
-	expect(field.find('input').getDOMNode().getAttribute('aria-invalid')).toBe('true');
+	const { container } = render(<Field name="username" />);
+	// The React prop `aria-invalid={true}` renders as the string "true".
+	expect(container.querySelector('input').getAttribute('aria-invalid')).toBe('true');
 });
 
 it('should set aria-invalid and aria-describedby when the field is invalid and the form submitted', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
-		isFieldInvalid: jest.fn(() => true),
-		isFieldTouched: jest.fn(() => false),
+		getFieldErrorDescribedBy: vi.fn(() => 'jfv1-error-username'),
+		isFieldInvalid: vi.fn(() => true),
+		isFieldTouched: vi.fn(() => false),
 		isSubmitted: true,
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field name="username" />);
-	expect(field.find('input').prop('aria-invalid')).toBe(true);
-	expect(field.find('input').prop('aria-describedby')).toBe('jfv1-error-username');
+	const { container } = render(<Field name="username" />);
+	const input = container.querySelector('input');
+	expect(input.getAttribute('aria-invalid')).toBe('true');
+	expect(input.getAttribute('aria-describedby')).toBe('jfv1-error-username');
 	expect(context.getFieldErrorDescribedBy).toHaveBeenCalledWith('username');
 });
 
 it('should not render aria-invalid when the field is valid, even touched', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(),
-		isFieldInvalid: jest.fn(() => false),
-		isFieldTouched: jest.fn(() => true),
+		getFieldErrorDescribedBy: vi.fn(),
+		isFieldInvalid: vi.fn(() => false),
+		isFieldTouched: vi.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field name="username" />);
-	expect(field.find('input').prop('aria-invalid')).toBe(undefined);
-	expect(field.find('input').getDOMNode().hasAttribute('aria-invalid')).toBe(false);
+	const { container } = render(<Field name="username" />);
+	expect(container.querySelector('input').hasAttribute('aria-invalid')).toBe(false);
 });
 
 it('should allow to override aria-invalid via props', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(),
-		isFieldInvalid: jest.fn(() => true),
-		isFieldTouched: jest.fn(() => true),
+		getFieldErrorDescribedBy: vi.fn(),
+		isFieldInvalid: vi.fn(() => true),
+		isFieldTouched: vi.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field aria-invalid={false} name="username" />);
-	expect(field.find('input').prop('aria-invalid')).toBe(false);
+	const { container } = render(<Field aria-invalid={false} name="username" />);
+	// The React prop `aria-invalid={false}` renders as the string "false".
+	expect(container.querySelector('input').getAttribute('aria-invalid')).toBe('false');
 });
 
 it('should point aria-describedby at the ids registered by the FieldErrors once touched', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(() => true),
+		getFieldErrorDescribedBy: vi.fn(() => 'jfv1-error-username'),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field name="username" />);
-	expect(field.find('input').prop('aria-describedby')).toBe('jfv1-error-username');
+	const { container } = render(<Field name="username" />);
+	expect(container.querySelector('input').getAttribute('aria-describedby')).toBe('jfv1-error-username');
 	expect(context.getFieldErrorDescribedBy).toHaveBeenCalledWith('username');
 });
 
 it('should merge a user aria-describedby with the registered error ids when revealed', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(() => true),
+		getFieldErrorDescribedBy: vi.fn(() => 'jfv1-error-username'),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(() => true),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field aria-describedby="my-hint" name="username" />);
-	expect(field.find('input').prop('aria-describedby')).toBe('my-hint jfv1-error-username');
+	const { container } = render(<Field aria-describedby="my-hint" name="username" />);
+	expect(container.querySelector('input').getAttribute('aria-describedby')).toBe('my-hint jfv1-error-username');
 });
 
 it('should keep only the user aria-describedby while not revealed', () => {
 	const context = {
-		getFieldErrorDescribedBy: jest.fn(() => 'jfv1-error-username'),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(() => false),
+		getFieldErrorDescribedBy: vi.fn(() => 'jfv1-error-username'),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(() => false),
 	};
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const field = mount(<Field aria-describedby="my-hint" name="username" />);
-	expect(field.find('input').prop('aria-describedby')).toBe('my-hint');
+	const { container } = render(<Field aria-describedby="my-hint" name="username" />);
+	expect(container.querySelector('input').getAttribute('aria-describedby')).toBe('my-hint');
 	expect(context.getFieldErrorDescribedBy).not.toHaveBeenCalled();
 });
 
 it('Default component input can be changed', () => {
 	const Component = () => 'component';
-	const field = mount(<Field component={Component} name="username" />);
-	expect(field.exists(Component)).toBe(true);
+	const { container } = render(<Field component={Component} name="username" />);
+	expect(container.textContent).toBe('component');
 });
 
 it('should call form.handleFieldChange() when field value changes', () => {
+	// React 16 pools synthetic events (they are nullified after dispatch), so
+	// the `target` fields are captured at call time instead of being read
+	// from the mock's recorded arguments afterwards.
+	let receivedTarget;
 	const context = {
-		handleFieldChange: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		handleFieldChange: vi.fn((event) => {
+			receivedTarget = { name: event.target.name, value: event.target.value };
+		}),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 
-	const field = mount(<Field type="text" name="username" />);
-	const input = field.find('input');
-	input.getDOMNode().value = 'newvalue';
-	input.simulate('change');
-	expect(context.handleFieldChange).toHaveBeenCalledWith(
-		expect.objectContaining({
-			target: expect.objectContaining({
-				name: 'username',
-				value: 'newvalue',
-			}),
-		}),
-	);
+	const { container } = render(<Field type="text" name="username" />);
+	fireEvent.change(container.querySelector('input'), { target: { value: 'newvalue' } });
+	expect(context.handleFieldChange).toHaveBeenCalledTimes(1);
+	expect(receivedTarget).toEqual({
+		name: 'username',
+		value: 'newvalue',
+	});
 });
 
 it('should call onChange handler passed as prop when field value changes', () => {
 	const context = {
-		handleFieldChange: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		handleFieldChange: vi.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const handleChange = jest.fn();
-	const field = mount(<Field type="text" onChange={handleChange} name="username" />);
-	const input = field.find('input');
-	input.getDOMNode().value = 'newvalue';
-	input.simulate('change');
-	expect(handleChange).toHaveBeenCalledWith(
-		expect.objectContaining({
-			target: expect.objectContaining({
-				name: 'username',
-				value: 'newvalue',
-			}),
-		}),
-		context.handleFieldChange,
-	);
+	// Pooled synthetic event (React 16): capture the target fields and the
+	// second argument at call time (see previous test).
+	let receivedTarget;
+	let receivedFormHandler;
+	const handleChange = vi.fn((event, formHandleFieldChange) => {
+		receivedTarget = { name: event.target.name, value: event.target.value };
+		receivedFormHandler = formHandleFieldChange;
+	});
+	const { container } = render(<Field type="text" onChange={handleChange} name="username" />);
+	fireEvent.change(container.querySelector('input'), { target: { value: 'newvalue' } });
+	expect(handleChange).toHaveBeenCalledTimes(1);
+	expect(receivedTarget).toEqual({
+		name: 'username',
+		value: 'newvalue',
+	});
+	expect(receivedFormHandler).toBe(context.handleFieldChange);
 	expect(context.handleFieldChange).not.toHaveBeenCalled();
 });
 
@@ -252,14 +256,14 @@ it('should wrap a raw string emitted by a non-DOM child into a synthetic event (
 		</button>
 	);
 	const context = {
-		handleFieldChange: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		handleFieldChange: vi.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 
-	const field = mount(<Field name="phone" component={RawEmitter} />);
-	field.find('button').simulate('click');
+	const { container } = render(<Field name="phone" component={RawEmitter} />);
+	fireEvent.click(container.querySelector('button'));
 
 	expect(context.handleFieldChange).toHaveBeenCalledWith({
 		target: { name: 'phone', value: '+1234567890' },
@@ -276,14 +280,14 @@ it('should wrap a raw object emitted by a non-DOM child into a synthetic event (
 		</button>
 	);
 	const context = {
-		handleFieldChange: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		handleFieldChange: vi.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 
-	const field = mount(<Field name="category" component={OptionEmitter} />);
-	field.find('button').simulate('click');
+	const { container } = render(<Field name="category" component={OptionEmitter} />);
+	fireEvent.click(container.querySelector('button'));
 
 	expect(context.handleFieldChange).toHaveBeenCalledWith({
 		target: { name: 'category', value: { value: 'foo', label: 'Foo' } },
@@ -300,15 +304,15 @@ it('should pass a raw value straight through to a user-supplied onChange without
 		</button>
 	);
 	const context = {
-		handleFieldChange: jest.fn(),
-		isFieldInvalid: jest.fn(),
-		isFieldTouched: jest.fn(),
+		handleFieldChange: vi.fn(),
+		isFieldInvalid: vi.fn(),
+		isFieldTouched: vi.fn(),
 	};
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
 
-	const handler = jest.fn();
-	const field = mount(<Field name="phone" component={RawEmitter} onChange={handler} />);
-	field.find('button').simulate('click');
+	const handler = vi.fn();
+	const { container } = render(<Field name="phone" component={RawEmitter} onChange={handler} />);
+	fireEvent.click(container.querySelector('button'));
 
 	expect(handler).toHaveBeenCalledWith('+1234567890', context.handleFieldChange);
 	expect(context.handleFieldChange).not.toHaveBeenCalled();

--- a/src/lib/Field/__snapshots__/Field.test.js.snap
+++ b/src/lib/Field/__snapshots__/Field.test.js.snap
@@ -1,26 +1,8 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should match snapshot 1`] = `
-<ForwardRef
+<input
+  class="Jfv_Field"
   name="username"
->
-  <Field
-    aria-describedby={null}
-    className=""
-    component="input"
-    forwardedRef={null}
-    name="username"
-    onBlur={null}
-    onChange={null}
-  >
-    <mockConstructor>
-      <input
-        className="Jfv_Field"
-        name="username"
-        onBlur={[Function]}
-        onChange={[Function]}
-      />
-    </mockConstructor>
-  </Field>
-</ForwardRef>
+/>
 `;

--- a/src/lib/FieldError/FieldError.test.js
+++ b/src/lib/FieldError/FieldError.test.js
@@ -1,50 +1,51 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import FormContext from '../Form/Context';
 import FieldError from './FieldError';
 
-jest.mock('../Form/Context');
+vi.mock('../Form/Context');
 
 // Minimal form context: the id registration lifecycles need `formId`,
 // `registerFieldError` and `unregisterFieldError` on every mount.
 const createContext = (overrides) => ({
 	formId: 'jfv1',
-	getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }]),
-	isFieldTouched: jest.fn(),
-	registerFieldError: jest.fn(),
-	unregisterFieldError: jest.fn(),
+	getFieldErrors: vi.fn(() => [{ keyword: 'bad1' }]),
+	isFieldTouched: vi.fn(),
+	registerFieldError: vi.fn(),
+	unregisterFieldError: vi.fn(),
 	...overrides,
 });
 
 it('should match snapshot', () => {
 	const context = createContext({
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad' }]),
+		getFieldErrors: vi.fn(() => [{ keyword: 'bad' }]),
 	});
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError name="username" />);
-	// Snapshot the rendered element only: the full wrapper would serialize
-	// the mocked `form` prop (jest.fn call records) — noisy and brittle.
-	expect(fieldError.find('div.Jfv_FieldError')).toMatchSnapshot();
+	const { container } = render(<FieldError name="username" />);
+	expect(container.querySelector('div.Jfv_FieldError')).toMatchSnapshot();
 });
 
 it('should not be displayed if field has no error', () => {
-	const fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find(FormContext.Consumer).exists()).toBe(true);
+	// The default mocked context returns no error: the consumer renders,
+	// but no error element reaches the DOM.
+	const { container } = render(<FieldError name="username" />);
+	expect(FormContext.Consumer).toHaveBeenCalled();
+	expect(container.firstChild).toBeNull();
 });
 
 it('should call error message of first error only if field has errors', () => {
 	const context = createContext({
 		errorMessages: {
-			bad1: jest.fn(),
-			bad2: jest.fn(),
+			bad1: vi.fn(),
+			bad2: vi.fn(),
 		},
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }, { keyword: 'bad2' }]),
+		getFieldErrors: vi.fn(() => [{ keyword: 'bad1' }, { keyword: 'bad2' }]),
 	});
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	mount(<FieldError name="username" />);
+	render(<FieldError name="username" />);
 	expect(context.errorMessages.bad1).toHaveBeenCalled();
 	expect(context.errorMessages.bad2).not.toHaveBeenCalled();
 });
@@ -52,15 +53,15 @@ it('should call error message of first error only if field has errors', () => {
 it('should allow to extend and override error messages defined in form', () => {
 	const context = createContext({
 		errorMessages: {
-			bad1: jest.fn(),
-			bad2: jest.fn(),
+			bad1: vi.fn(),
+			bad2: vi.fn(),
 		},
-		getFieldErrors: jest.fn(() => [{ keyword: 'bad1' }, { keyword: 'bad2' }]),
+		getFieldErrors: vi.fn(() => [{ keyword: 'bad1' }, { keyword: 'bad2' }]),
 	});
 
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const bad1Override = jest.fn();
-	mount(
+	const bad1Override = vi.fn();
+	render(
 		<FieldError
 			errorMessages={{ bad1: bad1Override }}
 			name="username"
@@ -69,10 +70,10 @@ it('should allow to extend and override error messages defined in form', () => {
 	expect(bad1Override).toHaveBeenCalled();
 	expect(context.errorMessages.bad1).not.toHaveBeenCalled();
 
-	context.getFieldErrors = jest.fn(() => [{ keyword: 'bad3' }]);
+	context.getFieldErrors = vi.fn(() => [{ keyword: 'bad3' }]);
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const bad3 = jest.fn();
-	mount(
+	const bad3 = vi.fn();
+	render(
 		<FieldError
 			errorMessages={{ bad3 }}
 			name="username"
@@ -85,58 +86,58 @@ it('should allow to extend and override error messages defined in form', () => {
 it('should render children if providen', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(
+	const { container } = render(
 		<FieldError name="username">
 			<span id="message" />
 		</FieldError>,
 	);
-	expect(fieldError.exists('#message')).toBe(true);
+	expect(container.querySelector('#message')).not.toBeNull();
 });
 
 it('should add class isSubmitted if form is submitted', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	let fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').hasClass('isSubmitted')).toBe(false);
+	let { container } = render(<FieldError name="username" />);
+	expect(container.querySelector('.Jfv_FieldError').classList.contains('isSubmitted')).toBe(false);
 
 	context.isSubmitted = true;
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').hasClass('isSubmitted')).toBe(true);
+	({ container } = render(<FieldError name="username" />));
+	expect(container.querySelector('.Jfv_FieldError').classList.contains('isSubmitted')).toBe(true);
 });
 
 it('should have role="alert" by default so errors are announced to screen readers', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').prop('role')).toBe('alert');
+	const { container } = render(<FieldError name="username" />);
+	expect(container.querySelector('.Jfv_FieldError').getAttribute('role')).toBe('alert');
 });
 
 it('should allow to override role via props', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError name="username" role="status" />);
-	expect(fieldError.find('.Jfv_FieldError').prop('role')).toBe('status');
+	const { container } = render(<FieldError name="username" role="status" />);
+	expect(container.querySelector('.Jfv_FieldError').getAttribute('role')).toBe('status');
 });
 
 it('should render a deterministic id prefixed by the formId', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').prop('id')).toBe('jfv1-error-username');
+	const { container } = render(<FieldError name="username" />);
+	expect(container.querySelector('.Jfv_FieldError').getAttribute('id')).toBe('jfv1-error-username');
 });
 
 it('should allow to override id via props', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError id="custom-id" name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').prop('id')).toBe('custom-id');
+	const { container } = render(<FieldError id="custom-id" name="username" />);
+	expect(container.querySelector('.Jfv_FieldError').getAttribute('id')).toBe('custom-id');
 });
 
 it('should register its default id in the form on mount', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	mount(<FieldError name="username" />);
+	render(<FieldError name="username" />);
 	expect(context.registerFieldError).toHaveBeenCalledTimes(1);
 	expect(context.registerFieldError).toHaveBeenCalledWith(
 		expect.any(String),
@@ -148,7 +149,7 @@ it('should register its default id in the form on mount', () => {
 it('should register a custom id in the form so Field aria-describedby follows it', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	mount(<FieldError id="custom-id" name="username" />);
+	render(<FieldError id="custom-id" name="username" />);
 	expect(context.registerFieldError).toHaveBeenCalledWith(
 		expect.any(String),
 		'username',
@@ -159,10 +160,10 @@ it('should register a custom id in the form so Field aria-describedby follows it
 it('should unregister its key from the form on unmount', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError name="username" />);
+	const { unmount } = render(<FieldError name="username" />);
 	const key = context.registerFieldError.mock.calls[0][0];
 
-	fieldError.unmount();
+	unmount();
 	expect(context.unregisterFieldError).toHaveBeenCalledTimes(1);
 	expect(context.unregisterFieldError).toHaveBeenCalledWith(key);
 });
@@ -172,9 +173,9 @@ it('should not re-register on updates that leave (name, id) unchanged', () => {
 	FormContext.Consumer
 		.mockImplementationOnce((props) => props.children(context))
 		.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError name="username" />);
+	const { rerender } = render(<FieldError name="username" />);
 
-	fieldError.setProps({ className: 'other' });
+	rerender(<FieldError className="other" name="username" />);
 	expect(context.registerFieldError).toHaveBeenCalledTimes(1);
 });
 
@@ -183,10 +184,10 @@ it('should re-register under the same key when its id changes', () => {
 	FormContext.Consumer
 		.mockImplementationOnce((props) => props.children(context))
 		.mockImplementationOnce((props) => props.children(context));
-	const fieldError = mount(<FieldError name="username" />);
+	const { rerender } = render(<FieldError name="username" />);
 	const key = context.registerFieldError.mock.calls[0][0];
 
-	fieldError.setProps({ id: 'new-id' });
+	rerender(<FieldError id="new-id" name="username" />);
 	expect(context.registerFieldError).toHaveBeenCalledTimes(2);
 	expect(context.registerFieldError).toHaveBeenLastCalledWith(key, 'username', 'new-id');
 });
@@ -194,11 +195,11 @@ it('should re-register under the same key when its id changes', () => {
 it('should add class isTouched if field is touched', () => {
 	const context = createContext();
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	let fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').hasClass('isTouched')).toBe(false);
+	let { container } = render(<FieldError name="username" />);
+	expect(container.querySelector('.Jfv_FieldError').classList.contains('isTouched')).toBe(false);
 
 	context.isFieldTouched.mockImplementation(() => true);
 	FormContext.Consumer.mockImplementationOnce((props) => props.children(context));
-	fieldError = mount(<FieldError name="username" />);
-	expect(fieldError.find('.Jfv_FieldError').hasClass('isTouched')).toBe(true);
+	({ container } = render(<FieldError name="username" />));
+	expect(container.querySelector('.Jfv_FieldError').classList.contains('isTouched')).toBe(true);
 });

--- a/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
+++ b/src/lib/FieldError/__snapshots__/FieldError.test.js.snap
@@ -1,8 +1,8 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should match snapshot 1`] = `
 <div
-  className="Jfv_FieldError"
+  class="Jfv_FieldError"
   id="jfv1-error-username"
   role="alert"
 />

--- a/src/lib/FieldError/getErrorMessage.js
+++ b/src/lib/FieldError/getErrorMessage.js
@@ -24,7 +24,9 @@ const getErrorMessage = (fieldError, errorMessages) => {
 
 	let message = customErrorMessage ? customErrorMessage(fieldError) : fieldError.message;
 
-	/* istanbul ignore next */
+	// `@preserve` keeps the pragma through esbuild (Vitest transform), which
+	// drops non-legal comments; istanbul only matches the comment's prefix.
+	/* istanbul ignore next -- @preserve */
 	if (typeof process !== 'undefined' && process?.env?.REACT_APP_JFV_DEBUG === 'true') {
 		message += ` [#${fieldError.keyword}]`;
 	}

--- a/src/lib/FieldError/getErrorMessage.test.js
+++ b/src/lib/FieldError/getErrorMessage.test.js
@@ -8,7 +8,7 @@ it('should return a message based on error keyword', () => {
 });
 
 it('should call the error message function with the error as parameter', () => {
-	const errMessage = jest.fn();
+	const errMessage = vi.fn();
 	const error = { keyword: 'err1' };
 	getErrorMessage(error, { err1: errMessage });
 	expect(errMessage).toHaveBeenCalledWith(error);
@@ -16,7 +16,7 @@ it('should call the error message function with the error as parameter', () => {
 
 it('should call the default message function if no handler exists for this error', () => {
 	const error = { keyword: 'err1' };
-	const defaultMessage = jest.fn();
+	const defaultMessage = vi.fn();
 	getErrorMessage(error, { defaultMessage });
 	expect(defaultMessage).toHaveBeenCalled();
 });

--- a/src/lib/Form/Context.test.js
+++ b/src/lib/Form/Context.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import FormContext, { useFormContext, withFormContext } from './Context';
 
@@ -16,23 +16,23 @@ describe('useFormContext', () => {
 			const context = useFormContext();
 			return <span>{context}</span>;
 		};
-		const wrapper = mount(
+		const { container } = render(
 			<FormContext.Provider value="FormContextSnapshot">
 				<UseContextComponent />
 			</FormContext.Provider>,
 		);
-		expect(wrapper).toMatchSnapshot();
+		expect(container.firstChild).toMatchSnapshot();
 	});
 });
 
 describe('withFormContext', () => {
 	it('should match snapshot', () => {
 		const WithContextComponent = () => withFormContext((context) => <span>{context}</span>);
-		const wrapper = mount(
+		const { container } = render(
 			<FormContext.Provider value="FormContextSnapshot">
 				<WithContextComponent />
 			</FormContext.Provider>,
 		);
-		expect(wrapper).toMatchSnapshot();
+		expect(container.firstChild).toMatchSnapshot();
 	});
 });

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -429,7 +429,7 @@ class Form extends PureComponent {
 	handleSubmitError = () => {
 		const { scrollToError } = this.props;
 		const { errors } = this.state;
-		/* istanbul ignore next */
+		/* istanbul ignore next -- @preserve */
 		if (typeof process !== 'undefined' && process?.env?.REACT_APP_JFV_DEBUG === 'true') {
 			console.log(errors); // eslint-disable-line no-console
 		}

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 
 import Form from './Form';
 import Field from '../Field';
@@ -16,7 +16,7 @@ const testSchema = {
 
 // jsdom does not implement Element#scrollIntoView: define a mock so the
 // native scrolling in Form.scrollToFirstError() can run and be asserted on.
-const scrollIntoViewMock = jest.fn();
+const scrollIntoViewMock = vi.fn();
 const originalScrollIntoView = Element.prototype.scrollIntoView;
 
 beforeAll(() => {
@@ -36,18 +36,16 @@ afterAll(() => {
 });
 
 it('should match snapshot', () => {
-	const wrapper = mount(<Form onSubmit={() => {}} schema={{}} />);
-	// Snapshot the rendered <form> element only: snapshotting the <Form>
-	// component would serialize its props — including the whole AJV instance,
-	// whose internal cache differs between run modes (flaky snapshot).
-	expect(wrapper.find('form')).toMatchSnapshot();
+	const { container } = render(<Form onSubmit={() => {}} schema={{}} />);
+	// Snapshot the rendered <form> element only (DOM snapshot).
+	expect(container.querySelector('form')).toMatchSnapshot();
 });
 
 it('should call onSubmit handler when form submitted', () => {
-	const onSubmit = jest.fn();
+	const onSubmit = vi.fn();
 	const data = { type: 'te' };
 
-	const wrapper = mount(
+	const { container } = render(
 		<Form
 			data={data}
 			onSubmit={onSubmit}
@@ -55,15 +53,15 @@ it('should call onSubmit handler when form submitted', () => {
 		/>,
 	);
 
-	wrapper.find('form').simulate('submit', { preventDefault() {} });
+	fireEvent.submit(container.querySelector('form'));
 	expect(onSubmit).toHaveBeenCalled();
 });
 
 it('should not call onSubmit handler as the form is not valid', () => {
-	const onSubmit = jest.fn();
+	const onSubmit = vi.fn();
 	const data = { type: 'pioiv' };
 
-	const wrapper = mount(
+	const { container } = render(
 		<Form
 			data={data}
 			onSubmit={onSubmit}
@@ -71,74 +69,79 @@ it('should not call onSubmit handler as the form is not valid', () => {
 		/>,
 	);
 
-	wrapper.find('form').simulate('submit', { preventDefault() {} });
+	fireEvent.submit(container.querySelector('form'));
 	expect(onSubmit).not.toHaveBeenCalled();
 });
 
 describe('resetOnSubmit prop', () => {
 	it('should reset the form state on a successful submit by default', () => {
-		const onSubmit = jest.fn();
+		const onSubmit = vi.fn();
 		const data = { type: 'te' };
 
-		const wrapper = mount(
+		const ref = React.createRef();
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={onSubmit}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
 
-		wrapper.instance().touch('type');
-		expect(wrapper.state().touchedFields).toEqual(['type']);
+		ref.current.touch('type');
+		expect(ref.current.state.touchedFields).toEqual(['type']);
 
-		wrapper.find('form').simulate('submit', { preventDefault() {} });
+		fireEvent.submit(container.querySelector('form'));
 
 		expect(onSubmit).toHaveBeenCalled();
-		expect(wrapper.state().touchedFields).toEqual([]);
-		expect(wrapper.state().isSubmitted).toBe(false);
+		expect(ref.current.state.touchedFields).toEqual([]);
+		expect(ref.current.state.isSubmitted).toBe(false);
 	});
 
 	it('should keep touched/submitted state on a successful submit when resetOnSubmit is false', () => {
-		const onSubmit = jest.fn();
+		const onSubmit = vi.fn();
 		const data = { type: 'te' };
 
-		const wrapper = mount(
+		const ref = React.createRef();
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={onSubmit}
+				ref={ref}
 				resetOnSubmit={false}
 				schema={testSchema}
 			/>,
 		);
 
-		wrapper.instance().touch('type');
-		wrapper.find('form').simulate('submit', { preventDefault() {} });
+		ref.current.touch('type');
+		fireEvent.submit(container.querySelector('form'));
 
 		// onSubmit still runs, but the visual state survives the submit (so a
 		// later server-side failure does not leave the user with a blank form
 		// state).
 		expect(onSubmit).toHaveBeenCalled();
-		expect(wrapper.state().touchedFields).toEqual(['type']);
-		expect(wrapper.state().isSubmitted).toBe(true);
+		expect(ref.current.state.touchedFields).toEqual(['type']);
+		expect(ref.current.state.isSubmitted).toBe(true);
 	});
 });
 
 describe('Form.reset()', () => {
 	it('should keep fieldErrorsVersion monotonic (the FieldError registry survives a reset)', () => {
-		const wrapper = mount(<Form onSubmit={() => {}} schema={{}} />);
-		const instance = wrapper.instance();
+		const ref = React.createRef();
+		render(<Form onSubmit={() => {}} ref={ref} schema={{}} />);
+		const instance = ref.current;
 
 		instance.registerFieldError('key', 'type', 'jfv1_type_err');
 		instance.touch('type');
-		const versionBeforeReset = wrapper.state().fieldErrorsVersion;
+		const versionBeforeReset = instance.state.fieldErrorsVersion;
 		expect(versionBeforeReset).toBeGreaterThan(0);
 
 		instance.reset();
 
 		// The touched/submitted state is wiped, but the version counter is
 		// preserved: the registry (instance Map) was not emptied by reset().
-		expect(wrapper.state().touchedFields).toEqual([]);
-		expect(wrapper.state().fieldErrorsVersion).toBe(versionBeforeReset);
+		expect(instance.state.touchedFields).toEqual([]);
+		expect(instance.state.fieldErrorsVersion).toBe(versionBeforeReset);
 	});
 });
 
@@ -146,26 +149,28 @@ describe('context reset()', () => {
 	it('should expose reset through the form context and reset the state when called', () => {
 		const data = { type: 'invalid-value' };
 
-		const wrapper = mount(
+		const ref = React.createRef();
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
 
-		wrapper.instance().touch('type');
+		ref.current.touch('type');
 		// Failed submit (invalid data): isSubmitted stays true, nothing resets.
-		wrapper.find('form').simulate('submit', { preventDefault() {} });
-		expect(wrapper.state().touchedFields).toEqual(['type']);
-		expect(wrapper.state().isSubmitted).toBe(true);
+		fireEvent.submit(container.querySelector('form'));
+		expect(ref.current.state.touchedFields).toEqual(['type']);
+		expect(ref.current.state.isSubmitted).toBe(true);
 
-		const context = wrapper.instance().getContext();
+		const context = ref.current.getContext();
 		expect(typeof context.reset).toBe('function');
 		context.reset();
 
-		expect(wrapper.state().touchedFields).toEqual([]);
-		expect(wrapper.state().isSubmitted).toBe(false);
+		expect(ref.current.state.touchedFields).toEqual([]);
+		expect(ref.current.state.isSubmitted).toBe(false);
 	});
 });
 
@@ -173,51 +178,59 @@ describe('Form.getFieldErrors()', () => {
 	it('should return a list of fields having errors', () => {
 		let data = { type: 'uuu' };
 
-		let wrapper = mount(
+		let ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
 
-		expect(wrapper.instance().getFieldErrors('type').length).toStrictEqual(1);
+		expect(ref.current.getFieldErrors('type').length).toStrictEqual(1);
 
 		data = { type: 'te' };
-		wrapper = mount(
+		ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
-		expect(wrapper.instance().getFieldErrors('type').length).toStrictEqual(0);
+		expect(ref.current.getFieldErrors('type').length).toStrictEqual(0);
 
 		data = { type: null };
-		wrapper = mount(
+		ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
-		expect(wrapper.instance().getFieldErrors('type').length).toStrictEqual(1);
+		expect(ref.current.getFieldErrors('type').length).toStrictEqual(1);
 	});
 });
 
 describe('Form.handleFieldChange(event, value)', () => {
 	it('should call onChange props with updated data based on event', () => {
 		const data = { type: 'uuu' };
-		const handleChange = jest.fn();
-		const wrapper = mount(
+		const handleChange = vi.fn();
+		const ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onChange={handleChange}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
-		const form = wrapper.instance();
+		const form = ref.current;
 		const event = {
 			target: {
 				name: 'type',
@@ -231,16 +244,18 @@ describe('Form.handleFieldChange(event, value)', () => {
 
 	it('should create an event like object if event param is a string', () => {
 		const data = { type: 'uuu' };
-		const handleChange = jest.fn();
-		const wrapper = mount(
+		const handleChange = vi.fn();
+		const ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onChange={handleChange}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
-		const form = wrapper.instance();
+		const form = ref.current;
 		const event = {
 			target: {
 				name: 'type',
@@ -254,15 +269,17 @@ describe('Form.handleFieldChange(event, value)', () => {
 
 	it('should not fail if onChange handler is not present', () => {
 		const data = { type: 'uuu' };
-		const wrapper = mount(
+		const ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
 
-		const form = wrapper.instance();
+		const form = ref.current;
 		const event = {
 			target: {
 				name: 'type',
@@ -277,9 +294,11 @@ describe('Form.handleFieldChange(event, value)', () => {
 
 describe('Form.isFieldTouched(fieldNames)', () => {
 	it('should return true if at least one of the fields named on the list is touched, false otherwise', () => {
-		const wrapper = mount(
+		const ref = React.createRef();
+		const { container } = render(
 			<Form
 				onSubmit={() => {}}
+				ref={ref}
 				schema={{}}
 			>
 				<Field
@@ -295,21 +314,21 @@ describe('Form.isFieldTouched(fieldNames)', () => {
 			</Form>,
 		);
 
-		expect(wrapper.instance().isFieldTouched(['type'])).toStrictEqual(false);
-		expect(wrapper.instance().isFieldTouched(['name'])).toStrictEqual(false);
-		expect(wrapper.instance().isFieldTouched(['type', 'name'])).toStrictEqual(false);
+		expect(ref.current.isFieldTouched(['type'])).toStrictEqual(false);
+		expect(ref.current.isFieldTouched(['name'])).toStrictEqual(false);
+		expect(ref.current.isFieldTouched(['type', 'name'])).toStrictEqual(false);
 
-		wrapper.find('#test-type').hostNodes().simulate('blur', { preventDefault() {} });
+		fireEvent.blur(container.querySelector('#test-type'));
 
-		expect(wrapper.instance().isFieldTouched(['type'])).toStrictEqual(true);
-		expect(wrapper.instance().isFieldTouched(['name'])).toStrictEqual(false);
-		expect(wrapper.instance().isFieldTouched(['type', 'name'])).toStrictEqual(true);
+		expect(ref.current.isFieldTouched(['type'])).toStrictEqual(true);
+		expect(ref.current.isFieldTouched(['name'])).toStrictEqual(false);
+		expect(ref.current.isFieldTouched(['type', 'name'])).toStrictEqual(true);
 
-		wrapper.find('#test-name').hostNodes().simulate('blur', { preventDefault() {} });
+		fireEvent.blur(container.querySelector('#test-name'));
 
-		expect(wrapper.instance().isFieldTouched(['type'])).toStrictEqual(true);
-		expect(wrapper.instance().isFieldTouched(['name'])).toStrictEqual(true);
-		expect(wrapper.instance().isFieldTouched(['type', 'name'])).toStrictEqual(true);
+		expect(ref.current.isFieldTouched(['type'])).toStrictEqual(true);
+		expect(ref.current.isFieldTouched(['name'])).toStrictEqual(true);
+		expect(ref.current.isFieldTouched(['type', 'name'])).toStrictEqual(true);
 	});
 });
 
@@ -332,32 +351,36 @@ describe('Form.isFieldInvalid(fieldNames)', () => {
 			],
 		};
 
-		let wrapper = mount(
+		let ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={newSchema}
 			/>,
 		);
 
-		expect(wrapper.instance().isFieldInvalid('type')).toBe(true);
-		expect(wrapper.instance().isFieldInvalid(['name'])).toBe(false);
+		expect(ref.current.isFieldInvalid('type')).toBe(true);
+		expect(ref.current.isFieldInvalid(['name'])).toBe(false);
 
 		const newData = {
 			type: 'te',
 			name: 'HE',
 		};
 
-		wrapper = mount(
+		ref = React.createRef();
+		render(
 			<Form
 				data={newData}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={newSchema}
 			/>,
 		);
 
-		expect(wrapper.instance().isFieldInvalid('type')).toBe(false);
-		expect(wrapper.instance().isFieldInvalid(['name'])).toBe(true);
+		expect(ref.current.isFieldInvalid('type')).toBe(false);
+		expect(ref.current.isFieldInvalid(['name'])).toBe(true);
 	});
 
 	it('should check every name of the list, not only the first one', () => {
@@ -380,15 +403,17 @@ describe('Form.isFieldInvalid(fieldNames)', () => {
 			],
 		};
 
-		const wrapper = mount(
+		const ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={newSchema}
 			/>,
 		);
 
-		expect(wrapper.instance().isFieldInvalid(['type', 'name'])).toBe(true);
+		expect(ref.current.isFieldInvalid(['type', 'name'])).toBe(true);
 	});
 });
 
@@ -398,7 +423,7 @@ describe('Form.scrollToFirstError()', () => {
 
 		// No <Field name="type"> rendered: document.getElementsByName('type')
 		// is empty when the submit fails.
-		const wrapper = mount(
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
@@ -407,16 +432,16 @@ describe('Form.scrollToFirstError()', () => {
 		);
 
 		expect(() => {
-			wrapper.find('form').simulate('submit', { preventDefault() {} });
+			fireEvent.submit(container.querySelector('form'));
 		}).not.toThrow();
 	});
 
 	it('should move focus to the first invalid field after a failed submit', () => {
 		const data = { type: 'invalid-value' };
-		const container = document.createElement('div');
-		document.body.appendChild(container);
 
-		const wrapper = mount(
+		// RTL renders inside document.body: document.getElementsByName and
+		// focus work without any manual attach/detach.
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
@@ -428,25 +453,17 @@ describe('Form.scrollToFirstError()', () => {
 					type="text"
 				/>
 			</Form>,
-			{ attachTo: container },
 		);
 
-		try {
-			wrapper.find('form').simulate('submit', { preventDefault() {} });
+		fireEvent.submit(container.querySelector('form'));
 
-			expect(document.activeElement).toBe(document.getElementById('test-type'));
-		} finally {
-			wrapper.detach();
-			document.body.removeChild(container);
-		}
+		expect(document.activeElement).toBe(document.getElementById('test-type'));
 	});
 
 	it('should scroll the first invalid field into view with smooth/center defaults', () => {
 		const data = { type: 'invalid-value' };
-		const container = document.createElement('div');
-		document.body.appendChild(container);
 
-		const wrapper = mount(
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
@@ -458,32 +475,24 @@ describe('Form.scrollToFirstError()', () => {
 					type="text"
 				/>
 			</Form>,
-			{ attachTo: container },
 		);
 
-		try {
-			wrapper.find('form').simulate('submit', { preventDefault() {} });
+		fireEvent.submit(container.querySelector('form'));
 
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({
-				behavior: 'smooth',
-				block: 'center',
-				inline: 'nearest',
-			});
-			// The element scrolled into view is the first invalid field.
-			expect(scrollIntoViewMock.mock.instances[0]).toBe(document.getElementById('test-type'));
-		} finally {
-			wrapper.detach();
-			document.body.removeChild(container);
-		}
+		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({
+			behavior: 'smooth',
+			block: 'center',
+			inline: 'nearest',
+		});
+		// The element scrolled into view is the first invalid field.
+		expect(scrollIntoViewMock.mock.instances[0]).toBe(document.getElementById('test-type'));
 	});
 
 	it('should map the legacy align option to block and ignore offset/duration/ease', () => {
 		const data = { type: 'invalid-value' };
-		const container = document.createElement('div');
-		document.body.appendChild(container);
 
-		const wrapper = mount(
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
@@ -501,32 +510,24 @@ describe('Form.scrollToFirstError()', () => {
 					type="text"
 				/>
 			</Form>,
-			{ attachTo: container },
 		);
 
-		try {
-			wrapper.find('form').simulate('submit', { preventDefault() {} });
+		fireEvent.submit(container.querySelector('form'));
 
-			// `align: 'top'` maps to `block: 'start'`; the unsupported legacy
-			// options are not forwarded to scrollIntoView.
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({
-				behavior: 'smooth',
-				block: 'start',
-				inline: 'nearest',
-			});
-		} finally {
-			wrapper.detach();
-			document.body.removeChild(container);
-		}
+		// `align: 'top'` maps to `block: 'start'`; the unsupported legacy
+		// options are not forwarded to scrollIntoView.
+		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({
+			behavior: 'smooth',
+			block: 'start',
+			inline: 'nearest',
+		});
 	});
 
 	it('should forward native scrollIntoView options as-is', () => {
 		const data = { type: 'invalid-value' };
-		const container = document.createElement('div');
-		document.body.appendChild(container);
 
-		const wrapper = mount(
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
@@ -543,30 +544,22 @@ describe('Form.scrollToFirstError()', () => {
 					type="text"
 				/>
 			</Form>,
-			{ attachTo: container },
 		);
 
-		try {
-			wrapper.find('form').simulate('submit', { preventDefault() {} });
+		fireEvent.submit(container.querySelector('form'));
 
-			expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
-			expect(scrollIntoViewMock).toHaveBeenCalledWith({
-				behavior: 'auto',
-				block: 'end',
-				inline: 'start',
-			});
-		} finally {
-			wrapper.detach();
-			document.body.removeChild(container);
-		}
+		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({
+			behavior: 'auto',
+			block: 'end',
+			inline: 'start',
+		});
 	});
 
 	it('should still move focus without throwing when the element does not implement scrollIntoView', () => {
 		const data = { type: 'invalid-value' };
-		const container = document.createElement('div');
-		document.body.appendChild(container);
 
-		const wrapper = mount(
+		const { container } = render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
@@ -578,7 +571,6 @@ describe('Form.scrollToFirstError()', () => {
 					type="text"
 				/>
 			</Form>,
-			{ attachTo: container },
 		);
 
 		const input = document.getElementById('test-type');
@@ -587,42 +579,41 @@ describe('Form.scrollToFirstError()', () => {
 		// scrollIntoView is not implemented at all.
 		input.scrollIntoView = undefined;
 
-		try {
-			expect(() => {
-				wrapper.find('form').simulate('submit', { preventDefault() {} });
-			}).not.toThrow();
+		expect(() => {
+			fireEvent.submit(container.querySelector('form'));
+		}).not.toThrow();
 
-			// Scrolling is skipped, but the a11y focus move still happens.
-			expect(scrollIntoViewMock).not.toHaveBeenCalled();
-			expect(document.activeElement).toBe(input);
-		} finally {
-			wrapper.detach();
-			document.body.removeChild(container);
-		}
+		// Scrolling is skipped, but the a11y focus move still happens.
+		expect(scrollIntoViewMock).not.toHaveBeenCalled();
+		expect(document.activeElement).toBe(input);
 	});
 
 	it('should not throw when called directly while the form has no errors', () => {
 		const data = { type: 'te' };
 
-		const wrapper = mount(
+		const ref = React.createRef();
+		render(
 			<Form
 				data={data}
 				onSubmit={() => {}}
+				ref={ref}
 				schema={testSchema}
 			/>,
 		);
 
 		expect(() => {
-			wrapper.instance().scrollToFirstError();
+			ref.current.scrollToFirstError();
 		}).not.toThrow();
 	});
 });
 
 describe('Form.isFieldTouched(fieldName)', () => {
 	it('should return true if the field of name "fieldName" is touched, false otherwise', () => {
-		const wrapper = mount(
+		const ref = React.createRef();
+		const { container } = render(
 			<Form
 				onSubmit={() => {}}
+				ref={ref}
 				schema={{}}
 			>
 				<Field
@@ -633,17 +624,19 @@ describe('Form.isFieldTouched(fieldName)', () => {
 			</Form>,
 		);
 
-		expect(wrapper.instance().isFieldTouched('type')).toStrictEqual(false);
-		wrapper.find('#test-type').hostNodes().simulate('blur');
-		expect(wrapper.instance().isFieldTouched('type')).toStrictEqual(true);
+		expect(ref.current.isFieldTouched('type')).toStrictEqual(false);
+		fireEvent.blur(container.querySelector('#test-type'));
+		expect(ref.current.isFieldTouched('type')).toStrictEqual(true);
 	});
 });
 
 describe('Form.isTouched()', () => {
 	it('should return true if one of the fields in the form is touched, false otherwise', () => {
-		const wrapper = mount(
+		const ref = React.createRef();
+		const { container } = render(
 			<Form
 				onSubmit={() => {}}
+				ref={ref}
 				schema={{}}
 			>
 				<Field
@@ -664,20 +657,22 @@ describe('Form.isTouched()', () => {
 			</Form>,
 		);
 
-		expect(wrapper.instance().isTouched()).toStrictEqual(false);
-		wrapper.find('#test-type').hostNodes().simulate('blur', { preventDefault() {} });
-		expect(wrapper.instance().isTouched()).toStrictEqual(true);
-		wrapper.find('#test-name').hostNodes().simulate('blur', { preventDefault() {} });
-		wrapper.find('#test-description').hostNodes().simulate('blur');
-		expect(wrapper.instance().isTouched()).toStrictEqual(true);
+		expect(ref.current.isTouched()).toStrictEqual(false);
+		fireEvent.blur(container.querySelector('#test-type'));
+		expect(ref.current.isTouched()).toStrictEqual(true);
+		fireEvent.blur(container.querySelector('#test-name'));
+		fireEvent.blur(container.querySelector('#test-description'));
+		expect(ref.current.isTouched()).toStrictEqual(true);
 	});
 });
 
 describe('Form.touch(fieldName)', () => {
 	it('should add the field named "fieldName" with true value in the touched list in form state', () => {
-		const wrapper = mount(
+		const ref = React.createRef();
+		render(
 			<Form
 				onSubmit={() => {}}
+				ref={ref}
 				schema={{}}
 			>
 				<Field
@@ -698,21 +693,22 @@ describe('Form.touch(fieldName)', () => {
 			</Form>,
 		);
 
-		expect(wrapper.state().touchedFields).toEqual([]);
-		wrapper.instance().touch('type');
-		expect(wrapper.state().touchedFields).toEqual(['type']);
-		wrapper.instance().touch('name');
-		expect(wrapper.state().touchedFields).toEqual(['type', 'name']);
-		wrapper.instance().touch('description');
-		expect(wrapper.state().touchedFields).toEqual(['type', 'name', 'description']);
+		expect(ref.current.state.touchedFields).toEqual([]);
+		ref.current.touch('type');
+		expect(ref.current.state.touchedFields).toEqual(['type']);
+		ref.current.touch('name');
+		expect(ref.current.state.touchedFields).toEqual(['type', 'name']);
+		ref.current.touch('description');
+		expect(ref.current.state.touchedFields).toEqual(['type', 'name', 'description']);
 	});
 });
 
 it('should clean the event loop when unmounting', () => {
-	const wrapper = mount(<Form onSubmit={() => {}} schema={{}} />);
-	const componentWillUnmountSpy = jest.spyOn(Form.prototype, 'componentWillUnmount');
-	const cancelSpy = jest.spyOn(wrapper.instance().throttledValidator, 'cancel');
-	wrapper.unmount();
+	const ref = React.createRef();
+	const { unmount } = render(<Form onSubmit={() => {}} ref={ref} schema={{}} />);
+	const componentWillUnmountSpy = vi.spyOn(Form.prototype, 'componentWillUnmount');
+	const cancelSpy = vi.spyOn(ref.current.throttledValidator, 'cancel');
+	unmount();
 	expect(componentWillUnmountSpy).toHaveBeenCalled();
 	expect(cancelSpy).toHaveBeenCalled();
 	componentWillUnmountSpy.mockRestore();

--- a/src/lib/Form/__mocks__/Context.js
+++ b/src/lib/Form/__mocks__/Context.js
@@ -1,22 +1,23 @@
 import React from 'react';
+import { vi } from 'vitest';
 
 const context = {
 	formId: 'jfv1',
-	getFieldErrorDescribedBy: jest.fn(),
-	getFieldErrors: jest.fn(() => []),
-	handleFieldChange: jest.fn(),
-	isFieldInvalid: jest.fn(),
-	isFieldTouched: jest.fn(),
-	registerFieldError: jest.fn(),
-	reset: jest.fn(),
-	touch: jest.fn(),
-	unregisterFieldError: jest.fn(),
+	getFieldErrorDescribedBy: vi.fn(),
+	getFieldErrors: vi.fn(() => []),
+	handleFieldChange: vi.fn(),
+	isFieldInvalid: vi.fn(),
+	isFieldTouched: vi.fn(),
+	registerFieldError: vi.fn(),
+	reset: vi.fn(),
+	touch: vi.fn(),
+	unregisterFieldError: vi.fn(),
 };
 
-const Consumer = jest.fn().mockImplementation((props) => props.children(context));
+const Consumer = vi.fn().mockImplementation((props) => props.children(context));
 
 export default {
 	Consumer,
 };
 
-export const withFormContext = jest.fn().mockImplementation((cb) => <Consumer>{cb}</Consumer>);
+export const withFormContext = vi.fn().mockImplementation((cb) => <Consumer>{cb}</Consumer>);

--- a/src/lib/Form/__snapshots__/Context.test.js.snap
+++ b/src/lib/Form/__snapshots__/Context.test.js.snap
@@ -1,17 +1,13 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`useFormContext should match snapshot 1`] = `
-<UseContextComponent>
-  <span>
-    FormContextSnapshot
-  </span>
-</UseContextComponent>
+exports[`useFormContext > should match snapshot 1`] = `
+<span>
+  FormContextSnapshot
+</span>
 `;
 
-exports[`withFormContext should match snapshot 1`] = `
-<WithContextComponent>
-  <span>
-    FormContextSnapshot
-  </span>
-</WithContextComponent>
+exports[`withFormContext > should match snapshot 1`] = `
+<span>
+  FormContextSnapshot
+</span>
 `;

--- a/src/lib/Form/__snapshots__/Form.test.js.snap
+++ b/src/lib/Form/__snapshots__/Form.test.js.snap
@@ -1,9 +1,8 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`should match snapshot 1`] = `
 <form
-  className="Jfv_Form"
-  noValidate={true}
-  onSubmit={[Function]}
+  class="Jfv_Form"
+  novalidate=""
 />
 `;

--- a/src/lib/Form/helpers.test.js
+++ b/src/lib/Form/helpers.test.js
@@ -1,6 +1,6 @@
 import Ajv from 'ajv';
 import React from 'react';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 
 import * as helpers from './helpers';
 
@@ -142,21 +142,21 @@ describe('.filterByFieldNameWithWildcard(fields, fieldName)', () => {
 
 describe('.getInputCheckboxValue(target)', () => {
 	it('should return a boolean depending on checked attribute', () => {
-		const input = mount(<input name="field" type="checkbox" />);
-		input.instance().checked = true;
-		const checkbox = input.getDOMNode();
+		const { container } = render(<input name="field" type="checkbox" />);
+		const checkbox = container.querySelector('input');
+		checkbox.checked = true;
 		expect(helpers.getInputCheckboxValue(checkbox)).toBe(true);
-		input.instance().checked = false;
+		checkbox.checked = false;
 		expect(helpers.getInputCheckboxValue(checkbox)).toBe(false);
-		input.instance().checked = undefined;
+		checkbox.checked = undefined;
 		expect(helpers.getInputCheckboxValue(checkbox)).toBe(false);
 	});
 });
 
 describe('.getInputFileValue(target)', () => {
 	it('should return a File if a file is selected and multiple attribute is false', () => {
-		const input = mount(<input name="field" type="file" />);
-		const file = input.getDOMNode();
+		const { container } = render(<input name="field" type="file" />);
+		const file = container.querySelector('input');
 		Object.defineProperty(file, 'files', { value: ['file1'], configurable: true });
 		Object.defineProperty(file, 'value', { value: 'path/file1' });
 		expect(helpers.getInputFileValue(file)).toBe('file1');
@@ -165,8 +165,8 @@ describe('.getInputFileValue(target)', () => {
 	});
 
 	it('should return a list of File if a file is selected and multiple attribute is true', () => {
-		const input = mount(<input name="field" type="file" />);
-		const file = input.getDOMNode();
+		const { container } = render(<input name="field" type="file" />);
+		const file = container.querySelector('input');
 		file.multiple = true;
 		Object.defineProperty(file, 'files', { value: ['file1'], configurable: true });
 		Object.defineProperty(file, 'value', { value: 'path/file1' });
@@ -176,8 +176,8 @@ describe('.getInputFileValue(target)', () => {
 	});
 
 	it('should an empty string if no file is selected', () => {
-		const input = mount(<input name="field" type="file" />);
-		const file = input.getDOMNode();
+		const { container } = render(<input name="field" type="file" />);
+		const file = container.querySelector('input');
 		expect(helpers.getInputFileValue(file)).toBe('');
 		file.multiple = true;
 		expect(helpers.getInputFileValue(file)).toBe('');
@@ -186,8 +186,8 @@ describe('.getInputFileValue(target)', () => {
 
 describe('.getInputNumberValue(target)', () => {
 	it('should return a Number if input is not empty', () => {
-		const input = mount(<input name="field" type="number" />);
-		const number = input.getDOMNode();
+		const { container } = render(<input name="field" type="number" />);
+		const number = container.querySelector('input');
 		number.value = 3;
 		expect(helpers.getInputNumberValue(number)).toBe(3);
 		number.value = Math.PI;
@@ -201,106 +201,106 @@ describe('.getInputNumberValue(target)', () => {
 	});
 
 	it('should an empty string if input is empty', () => {
-		const input = mount(<input name="field" type="number" />);
-		const number = input.getDOMNode();
+		const { container } = render(<input name="field" type="number" />);
+		const number = container.querySelector('input');
 		expect(helpers.getInputNumberValue(number)).toBe('');
 	});
 });
 
 describe('.getFieldValue(target)', () => {
-	it('should return string value for text input type text', (done) => {
-		const handleChange = ({ target }) => {
+	// The `expect`s live inside the change handlers (as in the original,
+	// `done`-based tests — Vitest does not support the `done` callback);
+	// asserting the handler ran replaces the `done()` guarantee.
+	it('should return string value for text input type text', () => {
+		const handleChange = vi.fn(({ target }) => {
 			const value = helpers.getFieldValue(target);
 			expect(value).toBe('newvalue');
-			done();
-		};
-		const input = mount(<input name="field" type="text" onChange={handleChange} />);
-		input.getDOMNode().value = 'newvalue';
-		input.simulate('change');
+		});
+		const { container } = render(<input name="field" type="text" onChange={handleChange} />);
+		fireEvent.change(container.querySelector('input'), { target: { value: 'newvalue' } });
+		expect(handleChange).toHaveBeenCalled();
 	});
 
-	it('should return a string value for textarea', (done) => {
-		const handleChange = (event) => {
+	it('should return a string value for textarea', () => {
+		const handleChange = vi.fn((event) => {
 			const { target } = event;
 			const value = helpers.getFieldValue(target);
 			expect(value).toBe('newvalue');
-			done();
-		};
-		const input = mount(<textarea name="field" type="text" onChange={handleChange} />);
-		input.instance().value = 'newvalue';
-		input.simulate('change');
+		});
+		const { container } = render(<textarea name="field" type="text" onChange={handleChange} />);
+		fireEvent.change(container.querySelector('textarea'), { target: { value: 'newvalue' } });
+		expect(handleChange).toHaveBeenCalled();
 	});
 
-	it('should return a boolean value for checkbox', (done) => {
-		const handleChange = (event) => {
+	it('should return a boolean value for checkbox', () => {
+		const handleChange = vi.fn((event) => {
 			const { target } = event;
 			const value = helpers.getFieldValue(target);
 			expect(value).toBe(true);
-			done();
-		};
-		const input = mount(<input name="field" type="checkbox" onChange={handleChange} />);
-		input.instance().checked = true;
-		input.simulate('change');
+		});
+		const { container } = render(<input name="field" type="checkbox" onChange={handleChange} />);
+		// React listens to click events for checkbox change detection.
+		fireEvent.click(container.querySelector('input'));
+		expect(handleChange).toHaveBeenCalled();
 	});
 
-	it('should return a string value for radio', (done) => {
-		const handleChange = (event) => {
+	it('should return a string value for radio', () => {
+		const handleChange = vi.fn((event) => {
 			const { target } = event;
 			const value = helpers.getFieldValue(target);
 			expect(value).toBe('value1');
-			done();
-		};
-		const input = mount(<input name="field" type="radio" value="value1" onChange={handleChange} />);
-		input.instance().checked = true;
-		input.simulate('change');
+		});
+		const { container } = render(<input name="field" type="radio" value="value1" onChange={handleChange} />);
+		// React listens to click events for radio change detection.
+		fireEvent.click(container.querySelector('input'));
+		expect(handleChange).toHaveBeenCalled();
 	});
 
-	it('should return a file or an array of files as value for input file', (done) => {
-		let handleChange = (event) => {
+	it('should return a file or an array of files as value for input file', () => {
+		const singleHandleChange = vi.fn((event) => {
 			const { target } = event;
 			const value = helpers.getFieldValue(target);
 			expect(value).toBe('file1');
-			done();
-		};
+		});
 
-		let input = mount(<input name="field" type="file" onChange={handleChange} />);
-		let domInput = input.getDOMNode();
+		let { container } = render(<input name="field" type="file" onChange={singleHandleChange} />);
+		let domInput = container.querySelector('input');
 		Object.defineProperty(domInput, 'files', {
 			value: ['file1'],
 		});
 		Object.defineProperty(domInput, 'value', {
 			value: 'path/file1',
 		});
-		input.simulate('change');
+		fireEvent.change(domInput);
+		expect(singleHandleChange).toHaveBeenCalled();
 
-		handleChange = (event) => {
+		const multipleHandleChange = vi.fn((event) => {
 			const { target } = event;
 			const value = helpers.getFieldValue(target);
 			expect(value).toEqual(['file1', 'file2']);
-			done();
-		};
+		});
 
-		input = mount(<input name="field" type="file" multiple onChange={handleChange} />);
-		domInput = input.getDOMNode();
+		({ container } = render(<input name="field" type="file" multiple onChange={multipleHandleChange} />));
+		domInput = container.querySelector('input');
 		Object.defineProperty(domInput, 'files', {
 			value: ['file1', 'file2'],
 		});
 		Object.defineProperty(domInput, 'value', {
 			value: 'path/file1',
 		});
-		input.simulate('change');
+		fireEvent.change(domInput);
+		expect(multipleHandleChange).toHaveBeenCalled();
 	});
 
-	it('should a number value for input number', (done) => {
-		const handleChange = (event) => {
+	it('should a number value for input number', () => {
+		const handleChange = vi.fn((event) => {
 			const { target } = event;
 			const value = helpers.getFieldValue(target);
 			expect(value).toBe(12.2);
-			done();
-		};
-		const input = mount(<input name="field" type="number" onChange={handleChange} />);
-		input.instance().value = '12.2';
-		input.simulate('change');
+		});
+		const { container } = render(<input name="field" type="number" onChange={handleChange} />);
+		fireEvent.change(container.querySelector('input'), { target: { value: '12.2' } });
+		expect(handleChange).toHaveBeenCalled();
 	});
 });
 
@@ -314,7 +314,7 @@ describe('.updateDataFromEvents(data, events)', () => {
 	});
 
 	it('should allow to pass events as a single Event or an array of Events', () => {
-		const spy = jest.spyOn(Array.prototype, 'forEach');
+		const spy = vi.spyOn(Array.prototype, 'forEach');
 		const data = { field: 'val' };
 		const event = { target: { name: 'field', value: 'newval' } };
 		helpers.updateDataFromEvents(data, [event]);

--- a/src/lib/Form/throttle.test.js
+++ b/src/lib/Form/throttle.test.js
@@ -2,15 +2,15 @@ import throttle from './throttle';
 
 describe('throttle(func, wait)', () => {
 	beforeEach(() => {
-		jest.useFakeTimers();
+		vi.useFakeTimers();
 	});
 
 	afterEach(() => {
-		jest.useRealTimers();
+		vi.useRealTimers();
 	});
 
 	it('should invoke immediately on the leading edge', () => {
-		const func = jest.fn();
+		const func = vi.fn();
 		const throttled = throttle(func, 200);
 
 		throttled('first');
@@ -20,7 +20,7 @@ describe('throttle(func, wait)', () => {
 	});
 
 	it('should coalesce calls made during the wait window into one trailing call with the latest arguments', () => {
-		const func = jest.fn();
+		const func = vi.fn();
 		const throttled = throttle(func, 200);
 
 		throttled('a');
@@ -31,7 +31,7 @@ describe('throttle(func, wait)', () => {
 		expect(func).toHaveBeenCalledTimes(1);
 		expect(func).toHaveBeenCalledWith('a');
 
-		jest.advanceTimersByTime(200);
+		vi.advanceTimersByTime(200);
 
 		// The two coalesced calls produced a single trailing invocation,
 		// carrying the most recent arguments.
@@ -40,17 +40,17 @@ describe('throttle(func, wait)', () => {
 	});
 
 	it('should not invoke a trailing call when no call happened during the wait window', () => {
-		const func = jest.fn();
+		const func = vi.fn();
 		const throttled = throttle(func, 200);
 
 		throttled('only');
-		jest.advanceTimersByTime(1000);
+		vi.advanceTimersByTime(1000);
 
 		expect(func).toHaveBeenCalledTimes(1);
 	});
 
 	it('cancel() should discard the pending trailing invocation', () => {
-		const func = jest.fn();
+		const func = vi.fn();
 		const throttled = throttle(func, 200);
 
 		throttled('a');
@@ -58,14 +58,14 @@ describe('throttle(func, wait)', () => {
 		expect(func).toHaveBeenCalledTimes(1);
 
 		throttled.cancel();
-		jest.advanceTimersByTime(1000);
+		vi.advanceTimersByTime(1000);
 
 		// The pending trailing call for 'b' never fires.
 		expect(func).toHaveBeenCalledTimes(1);
 	});
 
 	it('should allow a new leading invocation after cancel()', () => {
-		const func = jest.fn();
+		const func = vi.fn();
 		const throttled = throttle(func, 200);
 
 		throttled('a');

--- a/src/lib/a11y.test.js
+++ b/src/lib/a11y.test.js
@@ -7,7 +7,7 @@
  * <Field> points at it, instead of hardcoding `jfv1` everywhere.
  */
 import React from 'react';
-import { mount } from 'enzyme';
+import { fireEvent, render } from '@testing-library/react';
 
 import Form from './Form';
 import Field from './Field';
@@ -28,39 +28,39 @@ const formProps = {
 };
 
 it('should wire Field aria-describedby to the id rendered by FieldError once touched', () => {
-	const wrapper = mount(
+	const { container } = render(
 		<Form {...formProps}>
 			<Field name="username" />
 			<FieldError name="username" />
 		</Form>,
 	);
 
-	wrapper.find('input').simulate('blur');
-	wrapper.update();
+	const input = container.querySelector('input');
+	fireEvent.blur(input);
 
-	const errorId = wrapper.find('div.Jfv_FieldError').prop('id');
+	const errorId = container.querySelector('div.Jfv_FieldError').getAttribute('id');
 	expect(errorId).toMatch(/^jfv\d+-error-username$/);
-	expect(wrapper.find('input').prop('aria-describedby')).toBe(errorId);
-	expect(wrapper.find('input').prop('aria-invalid')).toBe(true);
+	expect(input.getAttribute('aria-describedby')).toBe(errorId);
+	expect(input.getAttribute('aria-invalid')).toBe('true');
 });
 
 it('should follow a custom FieldError id automatically', () => {
-	const wrapper = mount(
+	const { container } = render(
 		<Form {...formProps}>
 			<Field name="username" />
 			<FieldError id="my-custom-error" name="username" />
 		</Form>,
 	);
 
-	wrapper.find('input').simulate('blur');
-	wrapper.update();
+	const input = container.querySelector('input');
+	fireEvent.blur(input);
 
-	expect(wrapper.find('div.Jfv_FieldError').prop('id')).toBe('my-custom-error');
-	expect(wrapper.find('input').prop('aria-describedby')).toBe('my-custom-error');
+	expect(container.querySelector('div.Jfv_FieldError').getAttribute('id')).toBe('my-custom-error');
+	expect(input.getAttribute('aria-describedby')).toBe('my-custom-error');
 });
 
 it('should keep the error ids of two forms sharing a field name distinct', () => {
-	const wrapper = mount(
+	const { container } = render(
 		<div>
 			<Form {...formProps}>
 				<Field name="username" />
@@ -73,19 +73,20 @@ it('should keep the error ids of two forms sharing a field name distinct', () =>
 		</div>,
 	);
 
-	wrapper.find('input').at(0).simulate('blur');
-	wrapper.find('input').at(1).simulate('blur');
-	wrapper.update();
+	const inputs = container.querySelectorAll('input');
+	fireEvent.blur(inputs[0]);
+	fireEvent.blur(inputs[1]);
 
-	const ids = wrapper.find('div.Jfv_FieldError').map((node) => node.prop('id'));
+	const ids = [...container.querySelectorAll('div.Jfv_FieldError')]
+		.map((node) => node.getAttribute('id'));
 	expect(ids).toHaveLength(2);
 	expect(ids[0]).not.toBe(ids[1]);
-	expect(wrapper.find('input').at(0).prop('aria-describedby')).toBe(ids[0]);
-	expect(wrapper.find('input').at(1).prop('aria-describedby')).toBe(ids[1]);
+	expect(inputs[0].getAttribute('aria-describedby')).toBe(ids[0]);
+	expect(inputs[1].getAttribute('aria-describedby')).toBe(ids[1]);
 });
 
 it('should list every FieldError id of the field in mount order (IDREF list)', () => {
-	const wrapper = mount(
+	const { container } = render(
 		<Form {...formProps}>
 			<Field name="username" />
 			<FieldError name="username" />
@@ -93,11 +94,11 @@ it('should list every FieldError id of the field in mount order (IDREF list)', (
 		</Form>,
 	);
 
-	wrapper.find('input').simulate('blur');
-	wrapper.update();
+	const input = container.querySelector('input');
+	fireEvent.blur(input);
 
-	const firstId = wrapper.find('div.Jfv_FieldError').at(0).prop('id');
-	expect(wrapper.find('input').prop('aria-describedby')).toBe(`${firstId} second-error`);
+	const firstId = container.querySelectorAll('div.Jfv_FieldError')[0].getAttribute('id');
+	expect(input.getAttribute('aria-describedby')).toBe(`${firstId} second-error`);
 });
 
 it('should drop the id of an unmounted FieldError from aria-describedby', () => {
@@ -106,34 +107,33 @@ it('should drop the id of an unmounted FieldError from aria-describedby', () => 
 		<FieldError key="first" name="username" />,
 		<FieldError id="second-error" key="second" name="username" />,
 	];
-	const wrapper = mount(<Form {...formProps}>{children}</Form>);
+	const { container, rerender } = render(<Form {...formProps}>{children}</Form>);
 
-	wrapper.find('input').simulate('blur');
-	wrapper.update();
+	const input = container.querySelector('input');
+	fireEvent.blur(input);
 
-	const firstId = wrapper.find('div.Jfv_FieldError').at(0).prop('id');
-	expect(wrapper.find('input').prop('aria-describedby')).toBe(`${firstId} second-error`);
+	const firstId = container.querySelectorAll('div.Jfv_FieldError')[0].getAttribute('id');
+	expect(input.getAttribute('aria-describedby')).toBe(`${firstId} second-error`);
 
-	wrapper.setProps({ children: children.slice(0, 2) });
-	wrapper.update();
-	expect(wrapper.find('input').prop('aria-describedby')).toBe(firstId);
+	rerender(<Form {...formProps}>{children.slice(0, 2)}</Form>);
+	expect(input.getAttribute('aria-describedby')).toBe(firstId);
 });
 
 it('should merge a user aria-describedby before the registered error ids', () => {
-	const wrapper = mount(
+	const { container } = render(
 		<Form {...formProps}>
 			<Field aria-describedby="username-hint" name="username" />
 			<FieldError name="username" />
 		</Form>,
 	);
 
-	expect(wrapper.find('input').prop('aria-describedby')).toBe('username-hint');
+	const input = container.querySelector('input');
+	expect(input.getAttribute('aria-describedby')).toBe('username-hint');
 
-	wrapper.find('input').simulate('blur');
-	wrapper.update();
+	fireEvent.blur(input);
 
-	const errorId = wrapper.find('div.Jfv_FieldError').prop('id');
-	expect(wrapper.find('input').prop('aria-describedby')).toBe(`username-hint ${errorId}`);
+	const errorId = container.querySelector('div.Jfv_FieldError').getAttribute('id');
+	expect(input.getAttribute('aria-describedby')).toBe(`username-hint ${errorId}`);
 });
 
 it('should reference a wildcard FieldError id from the fields it covers', () => {
@@ -150,28 +150,29 @@ it('should reference a wildcard FieldError id from the fields it covers', () => 
 		},
 		required: ['user'],
 	};
-	const wrapper = mount(
+	const { container } = render(
 		<Form data={{ user: {} }} onSubmit={() => {}} schema={nestedSchema}>
 			<Field name="user.email" />
 			<FieldError name="user.*" />
 		</Form>,
 	);
 
-	wrapper.find('input').simulate('blur');
-	wrapper.update();
+	const input = container.querySelector('input');
+	fireEvent.blur(input);
 
-	const errorId = wrapper.find('div.Jfv_FieldError').prop('id');
+	const errorId = container.querySelector('div.Jfv_FieldError').getAttribute('id');
 	expect(errorId).toMatch(/^jfv\d+-error-user\.\*$/);
-	expect(wrapper.find('input').prop('aria-describedby')).toBe(errorId);
+	expect(input.getAttribute('aria-describedby')).toBe(errorId);
 });
 
 it('should reset the unmounting flag on remount (React 18 StrictMode)', () => {
-	const wrapper = mount(
-		<Form {...formProps}>
+	const ref = React.createRef();
+	const { unmount } = render(
+		<Form {...formProps} ref={ref}>
 			<FieldError name="username" />
 		</Form>,
 	);
-	const instance = wrapper.instance();
+	const instance = ref.current;
 	expect(instance.fieldErrorRegistry.size).toBe(1);
 	const key = [...instance.fieldErrorRegistry.keys()][0];
 
@@ -184,34 +185,35 @@ it('should reset the unmounting flag on remount (React 18 StrictMode)', () => {
 	instance.unregisterFieldError(key);
 	expect(instance.fieldErrorRegistry.size).toBe(0);
 
-	wrapper.unmount();
+	unmount();
 });
 
 it('should make unregisterFieldError a no-op while the form unmounts', () => {
-	const wrapper = mount(
-		<Form {...formProps}>
+	const ref = React.createRef();
+	const { unmount } = render(
+		<Form {...formProps} ref={ref}>
 			<FieldError name="username" />
 		</Form>,
 	);
-	const instance = wrapper.instance();
+	const instance = ref.current;
 	expect(instance.fieldErrorRegistry.size).toBe(1);
 	const key = [...instance.fieldErrorRegistry.keys()][0];
 
 	// Simulate the unmount sequence: the Form's willUnmount runs first and
 	// raises the flag, then the child FieldError unregisters.
 	instance.componentWillUnmount();
-	const setStateSpy = jest.spyOn(instance, 'setState');
+	const setStateSpy = vi.spyOn(instance, 'setState');
 	instance.unregisterFieldError(key);
 
 	expect(setStateSpy).not.toHaveBeenCalled();
 	expect(instance.fieldErrorRegistry.size).toBe(1);
 
 	setStateSpy.mockRestore();
-	wrapper.unmount();
+	unmount();
 });
 
 it('should unmount a whole form silently (unregister no-op while unmounting)', () => {
-	const wrapper = mount(
+	const { unmount } = render(
 		<Form {...formProps}>
 			<Field name="username" />
 			<FieldError name="username" />
@@ -221,9 +223,9 @@ it('should unmount a whole form silently (unregister no-op while unmounting)', (
 	// Without the `unmounting` flag, the unregister fired by the child
 	// FieldError would setState on the Form being destroyed, and React
 	// would report it through console.error.
-	const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+	const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 	try {
-		expect(() => wrapper.unmount()).not.toThrow();
+		expect(() => unmount()).not.toThrow();
 		expect(errorSpy).not.toHaveBeenCalled();
 	} finally {
 		errorSpy.mockRestore();

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,12 +1,9 @@
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-configure({ adapter: new Adapter() });
+import { vi } from 'vitest';
 
 const localStorageMock = {
-	getItem: jest.fn(() => null),
-	setItem: jest.fn(),
-	clear: jest.fn(),
+	getItem: vi.fn(() => null),
+	setItem: vi.fn(),
+	clear: vi.fn(),
 };
 
 global.localStorage = localStorageMock;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,26 @@
+import { coverageConfigDefaults, defineConfig, mergeConfig } from 'vitest/config';
+
+import viteConfig from './vite.config';
+
+// Reuses the demo's Vite config (JSX-in-.js esbuild recipe, classic JSX
+// runtime for React 16) so the tests parse the exact same sources as the
+// bundler, and only adds the test-specific settings on top.
+export default mergeConfig(viteConfig, defineConfig({
+	test: {
+		environment: 'jsdom',
+		globals: true,
+		setupFiles: ['src/setupTests.js'],
+		coverage: {
+			provider: 'istanbul',
+			// Parity with the previous Jest `collectCoverageFrom`
+			// (src/lib/**/*.{js,jsx,ts,tsx}); `all` reports files never
+			// imported by any test, as Jest did.
+			all: true,
+			include: ['src/lib/**/*.{js,jsx,ts,tsx}'],
+			// Keep the default exclusions (test files, configs…) and also
+			// leave the manual mocks out of the report, as Jest did.
+			exclude: [...coverageConfigDefaults.exclude, '**/__mocks__/**'],
+			reporter: ['text', 'json', 'json-summary', 'lcov'],
+		},
+	},
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@asamuzakjp/css-color@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
+  integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.3"
+    "@csstools/css-color-parser" "^3.0.9"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@babel/cli@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.4.tgz#505fb053721a98777b2b175323ea4f090b7d3c1c"
@@ -25,7 +36,7 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
-"@babel/code-frame@^7.29.7":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
   integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
@@ -69,7 +80,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.28.0":
+"@babel/core@^7.23.9", "@babel/core@^7.28.0":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
   integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
@@ -400,7 +411,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
   integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
 
-"@babel/parser@^7.20.7", "@babel/parser@^7.29.8":
+"@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.25.4", "@babel/parser@^7.29.8":
   version "7.29.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
   integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
@@ -1025,6 +1036,11 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.12.5":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/template@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
@@ -1078,7 +1094,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.20.7", "@babel/types@^7.29.8":
+"@babel/types@^7.20.7", "@babel/types@^7.25.4", "@babel/types@^7.29.8":
   version "7.29.8"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
   integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
@@ -1102,10 +1118,38 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@csstools/color-helpers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
+  integrity sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
+
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.4.tgz#8473f63e2fcd6e459838dd412401d5948f224c65"
+  integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
+
+"@csstools/css-color-parser@^3.0.9":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz#4e386af3a99dd36c46fef013cfe4c1c341eed6f0"
+  integrity sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==
+  dependencies:
+    "@csstools/color-helpers" "^5.1.0"
+    "@csstools/css-calc" "^2.1.4"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz#5755370a9a29abaec5515b43c8b3f2cf9c2e3076"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
 "@csstools/normalize.css@^10.1.0":
   version "10.1.0"
@@ -1336,6 +1380,23 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -1505,12 +1566,12 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
+"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -1618,6 +1679,11 @@
     "@parcel/watcher-linux-x64-musl" "2.6.0"
     "@parcel/watcher-win32-arm64" "2.6.0"
     "@parcel/watcher-win32-x64" "2.6.0"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
@@ -1852,6 +1918,34 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
+"@testing-library/dom@^8.0.0":
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.1.tgz#2e52a32e46fc88369eef7eef634ac2a192decd9f"
+  integrity sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.1.3"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    pretty-format "^27.0.2"
+
+"@testing-library/react@^12.1.5":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -1906,7 +2000,7 @@
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
 
-"@types/estree@1.0.9":
+"@types/estree@1.0.9", "@types/estree@^1.0.0":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.9.tgz#cf3f0e876d7bee15a93ab925b82bf570a3904a24"
   integrity sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==
@@ -1979,6 +2073,11 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
+
+"@types/react-dom@<18.0.0":
+  version "17.0.26"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.26.tgz#fa7891ba70fd39ddbaa7e85b6ff9175bb546bc1b"
+  integrity sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==
 
 "@types/react-dom@^16.9.25":
   version "16.9.25"
@@ -2070,6 +2169,81 @@
     "@rolldown/pluginutils" "1.0.0-beta.27"
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
+
+"@vitest/coverage-istanbul@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-istanbul/-/coverage-istanbul-2.1.9.tgz#064b50346fe3804e29c11792a3931090e0663151"
+  integrity sha512-vdYE4FkC/y2lxcN3Dcj54Bw+ericmDwiex0B8LV5F/YNYEYP1mgVwhPnHwWGAXu38qizkjOuyczKbFTALfzFKw==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.3"
+    debug "^4.3.7"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-instrument "^6.0.3"
+    istanbul-lib-report "^3.0.1"
+    istanbul-lib-source-maps "^5.0.6"
+    istanbul-reports "^3.1.7"
+    magicast "^0.3.5"
+    test-exclude "^7.0.1"
+    tinyrainbow "^1.2.0"
+
+"@vitest/expect@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.9.tgz#b566ea20d58ea6578d8dc37040d6c1a47ebe5ff8"
+  integrity sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    tinyrainbow "^1.2.0"
+
+"@vitest/mocker@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.9.tgz#36243b27351ca8f4d0bbc4ef91594ffd2dc25ef5"
+  integrity sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+
+"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.9.tgz#434ff2f7611689f9ce70cd7d567eceb883653fdf"
+  integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
+  dependencies:
+    tinyrainbow "^1.2.0"
+
+"@vitest/runner@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.1.9.tgz#cc18148d2d797fd1fd5908d1f1851d01459be2f6"
+  integrity sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==
+  dependencies:
+    "@vitest/utils" "2.1.9"
+    pathe "^1.1.2"
+
+"@vitest/snapshot@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.1.9.tgz#24260b93f798afb102e2dcbd7e61c6dfa118df91"
+  integrity sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+
+"@vitest/spy@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.9.tgz#cb28538c5039d09818b8bfa8edb4043c94727c60"
+  integrity sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.9.tgz#4f2486de8a54acf7ecbf2c5c24ad7994a680a6c1"
+  integrity sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    loupe "^3.1.2"
+    tinyrainbow "^1.2.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -2297,6 +2471,11 @@ adjust-sourcemap-loader@2.0.0:
     object-path "0.11.4"
     regex-parser "2.2.10"
 
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
 aggregate-error@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
@@ -2393,6 +2572,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -2419,6 +2603,16 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -2448,6 +2642,13 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.1.3.tgz#19db27cd101152773631396f7a95a3b58c22c35e"
+  integrity sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==
+  dependencies:
+    deep-equal "^2.0.5"
+
 aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
@@ -2475,6 +2676,14 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
+array-buffer-byte-length@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz#384d12a37295aec3769ab022ad323a18a51ccf8b"
+  integrity sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==
+  dependencies:
+    call-bound "^1.0.3"
+    is-array-buffer "^3.0.5"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -2583,6 +2792,11 @@ assert@^1.1.1:
   dependencies:
     object-assign "^4.1.1"
     util "0.10.3"
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -2837,6 +3051,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
@@ -2961,6 +3180,20 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
+  dependencies:
+    balanced-match "^1.0.0"
+
+brace-expansion@^5.0.8:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
@@ -3138,6 +3371,11 @@ bytes@~3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 cacache@^12.0.2:
   version "12.0.3"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.3.tgz#be99abba4e1bf5df461cd5a2c1071fc432573390"
@@ -3206,7 +3444,7 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bind@^1.0.9:
+call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.7, call-bind@^1.0.8, call-bind@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
   integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
@@ -3308,6 +3546,17 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
+chai@^5.1.2:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
@@ -3336,10 +3585,23 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 cheerio@^1.0.0-rc.3:
   version "1.0.0-rc.3"
@@ -3582,7 +3844,7 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -3857,6 +4119,15 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -4087,6 +4358,14 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
+cssstyle@^4.1.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.6.0.tgz#ea18007024e3167f4f105315f3ec2d982bf48ed9"
+  integrity sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==
+  dependencies:
+    "@asamuzakjp/css-color" "^3.2.0"
+    rrweb-cssom "^0.8.0"
+
 csstype@^2.5.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
@@ -4131,12 +4410,27 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@4, debug@^4.3.1, debug@^4.3.4, debug@^4.3.7:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
@@ -4152,22 +4446,25 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.1:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
-
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decimal.js@^10.4.3:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-equal@^1.0.1, deep-equal@^1.1.1:
   version "1.1.1"
@@ -4180,6 +4477,30 @@ deep-equal@^1.0.1, deep-equal@^1.1.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
+
+deep-equal@^2.0.5:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-2.2.3.tgz#af89dafb23a396c7da3e862abc0be27cf51d56e1"
+  integrity sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    call-bind "^1.0.5"
+    es-get-iterator "^1.1.3"
+    get-intrinsic "^1.2.2"
+    is-arguments "^1.1.1"
+    is-array-buffer "^3.0.2"
+    is-date-object "^1.0.5"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    isarray "^2.0.5"
+    object-is "^1.1.5"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.5.1"
+    side-channel "^1.0.4"
+    which-boxed-primitive "^1.0.2"
+    which-collection "^1.0.1"
+    which-typed-array "^1.1.13"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4194,7 +4515,7 @@ default-gateway@^4.2.0:
     execa "^1.0.0"
     ip-regex "^2.1.0"
 
-define-data-property@^1.1.4:
+define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
   integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
@@ -4209,6 +4530,15 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+define-properties@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
+  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
+  dependencies:
+    define-data-property "^1.0.1"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -4365,6 +4695,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
 dom-converter@^0.2:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -4494,6 +4829,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -4553,6 +4893,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -4588,6 +4933,11 @@ entities@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
   integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 enzyme-adapter-react-16@^1.15.2:
   version "1.15.2"
@@ -4701,12 +5051,42 @@ es-errors@^1.3.0:
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
+es-get-iterator@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/es-get-iterator/-/es-get-iterator-1.1.3.tgz#3ef87523c5d464d41084b2c3c9c214f1199763d6"
+  integrity sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    is-arguments "^1.1.1"
+    is-map "^2.0.2"
+    is-set "^2.0.2"
+    is-string "^1.0.7"
+    isarray "^2.0.5"
+    stop-iteration-iterator "^1.0.0"
+
+es-module-lexer@^1.5.4:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
   integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -5071,6 +5451,13 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5141,6 +5528,11 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+expect-type@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.4.0.tgz#24edf7f0cc69a44d008567ba4594ab96f3c3a3d6"
+  integrity sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==
 
 expect@^24.9.0:
   version "24.9.0"
@@ -5484,6 +5876,14 @@ for-own@^0.1.3:
   dependencies:
     for-in "^1.0.1"
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -5502,6 +5902,17 @@ fork-ts-checker-webpack-plugin@3.1.1:
     semver "^5.6.0"
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
+
+form-data@^4.0.0:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -5638,6 +6049,11 @@ functions-have-names@^1.2.0:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.1.tgz#a981ac397fa0c9964551402cdc5533d7a4d52f91"
   integrity sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==
 
+functions-have-names@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
@@ -5658,7 +6074,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
+get-intrinsic@^1.1.3, get-intrinsic@^1.2.2, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -5737,6 +6153,18 @@ glob@7.x, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^10.4.1:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 global-modules@2.0.0:
   version "2.0.0"
@@ -5848,6 +6276,11 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-bigints@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
+  integrity sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -5858,7 +6291,7 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-property-descriptors@^1.0.2:
+has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
   integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
@@ -5946,7 +6379,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hasown@^2.0.2:
+hasown@^2.0.2, hasown@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
@@ -6035,6 +6468,13 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
 html-entities@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
@@ -6113,6 +6553,14 @@ http-parser-js@>=0.5.1:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.10.tgz#b3277bd6d7ed5588e20ea73bf724fcbe44609075"
   integrity sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==
 
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
@@ -6146,12 +6594,27 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
@@ -6319,6 +6782,15 @@ internal-slot@^1.0.2:
     has "^1.0.3"
     side-channel "^1.0.2"
 
+internal-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.1.0.tgz#1eac91762947d2f7056bc838d93e13b2e9604961"
+  integrity sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==
+  dependencies:
+    es-errors "^1.3.0"
+    hasown "^2.0.2"
+    side-channel "^1.1.0"
+
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -6375,6 +6847,23 @@ is-arguments@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
   integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
 
+is-arguments@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
+  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
+
+is-array-buffer@^3.0.2, is-array-buffer@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
+  integrity sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    get-intrinsic "^1.2.6"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -6384,6 +6873,13 @@ is-arrayish@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
   integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
+is-bigint@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.1.0.tgz#dda7a3445df57a42583db4228682eba7c4170672"
+  integrity sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==
+  dependencies:
+    has-bigints "^1.0.2"
 
 is-binary-path@^1.0.0:
   version "1.0.1"
@@ -6403,6 +6899,14 @@ is-boolean-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.1.tgz#10edc0900dd127697a92f6f9807c7617d68ac48e"
   integrity sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==
+
+is-boolean-object@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz#7067f47709809a393c71ff5bb3e135d8a9215d9e"
+  integrity sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
 
 is-buffer@^1.0.2, is-buffer@^1.1.5:
   version "1.1.6"
@@ -6456,6 +6960,14 @@ is-date-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
   integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+
+is-date-object@^1.0.5:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.1.0.tgz#ad85541996fc7aa8b2729701d27b7319f95d82f7"
+  integrity sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -6540,10 +7052,23 @@ is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
+is-map@^2.0.2, is-map@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
+  integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
+
 is-number-object@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.4.tgz#36ac95e741cf18b283fc1ddf5e83da798e3ec197"
   integrity sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==
+
+is-number-object@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.1.1.tgz#144b21e95a1bc148205dcc2814a9134ec41b2541"
+  integrity sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -6593,6 +7118,11 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
@@ -6604,6 +7134,16 @@ is-regex@^1.0.4, is-regex@^1.0.5:
   integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
   dependencies:
     has "^1.0.3"
+
+is-regex@^1.1.4, is-regex@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
+  integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
+  dependencies:
+    call-bound "^1.0.2"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 is-regexp@^1.0.0:
   version "1.0.0"
@@ -6620,6 +7160,18 @@ is-root@2.1.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
+is-set@^2.0.2, is-set@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
+  integrity sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==
+
+is-shared-array-buffer@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz#9b67844bd9b7f246ba0708c3a93e34269c774f6f"
+  integrity sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==
+  dependencies:
+    call-bound "^1.0.3"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -6629,6 +7181,14 @@ is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
   integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
+
+is-string@^1.0.7, is-string@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.1.1.tgz#92ea3f3d5c5b6e039ca8677e5ac8d07ea773cbb9"
+  integrity sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
 
 is-subset@^0.1.1:
   version "0.1.1"
@@ -6649,6 +7209,15 @@ is-symbol@^1.0.2:
   dependencies:
     has-symbols "^1.0.1"
 
+is-symbol@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.1.1.tgz#f47761279f532e2b05a7024a7506dbbedacd0634"
+  integrity sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==
+  dependencies:
+    call-bound "^1.0.2"
+    has-symbols "^1.1.0"
+    safe-regex-test "^1.1.0"
+
 is-typed-array@^1.1.14:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
@@ -6660,6 +7229,19 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-weakmap@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
+  integrity sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==
+
+is-weakset@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.4.tgz#c9f5deb0bc1906c6d6f1027f284ddf459249daca"
+  integrity sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==
+  dependencies:
+    call-bound "^1.0.3"
+    get-intrinsic "^1.2.6"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -6713,6 +7295,11 @@ istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
   integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
 
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
 istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
@@ -6726,6 +7313,17 @@ istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
     istanbul-lib-coverage "^2.0.5"
     semver "^6.0.0"
 
+istanbul-lib-instrument@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
+
 istanbul-lib-report@^2.0.4:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
@@ -6734,6 +7332,15 @@ istanbul-lib-report@^2.0.4:
     istanbul-lib-coverage "^2.0.5"
     make-dir "^2.1.0"
     supports-color "^6.1.0"
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
 
 istanbul-lib-source-maps@^3.0.1:
   version "3.0.6"
@@ -6746,12 +7353,38 @@ istanbul-lib-source-maps@^3.0.1:
     rimraf "^2.6.3"
     source-map "^0.6.1"
 
+istanbul-lib-source-maps@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
+  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.23"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+
 istanbul-reports@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.7.tgz#5d939f6237d7b48393cc0959eab40cd4fd056931"
   integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
   dependencies:
     html-escaper "^2.0.0"
+
+istanbul-reports@^3.1.7:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
 
 jest-changed-files@^24.9.0:
   version "24.9.0"
@@ -7227,6 +7860,33 @@ jsdom@^14.1.0:
     ws "^6.1.2"
     xml-name-validator "^3.0.0"
 
+jsdom@^25.0.1:
+  version "25.0.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-25.0.1.tgz#536ec685c288fc8a5773a65f82d8b44badcc73ef"
+  integrity sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==
+  dependencies:
+    cssstyle "^4.1.0"
+    data-urls "^5.0.0"
+    decimal.js "^10.4.3"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.5"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.12"
+    parse5 "^7.1.2"
+    rrweb-cssom "^0.7.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^5.0.0"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -7556,10 +8216,20 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+
+lru-cache@^10.2.0, lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -7567,6 +8237,27 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
+magic-string@^0.30.12:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+
+magicast@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.3.5.tgz#8301c3c7d66704a0771eb1bad74274f0ec036739"
+  integrity sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==
+  dependencies:
+    "@babel/parser" "^7.25.4"
+    "@babel/types" "^7.25.4"
+    source-map-js "^1.2.0"
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
@@ -7582,6 +8273,13 @@ make-dir@^3.0.0:
   integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
   dependencies:
     semver "^6.0.0"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -7759,7 +8457,7 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   dependencies:
     mime-db "1.43.0"
 
-mime-types@~2.1.34:
+mime-types@^2.1.35, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -7817,6 +8515,20 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^10.2.2:
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
+  integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
+  dependencies:
+    brace-expansion "^5.0.8"
+
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -7854,6 +8566,11 @@ minipass@^3.0.0, minipass@^3.1.1:
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
   dependencies:
     yallist "^4.0.0"
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -8177,6 +8894,11 @@ nwsapi@^2.0.7, nwsapi@^2.1.3:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
+nwsapi@^2.2.12:
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -8216,6 +8938,14 @@ object-is@^1.0.1, object-is@^1.0.2:
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.2.tgz#6b80eb84fe451498f65007982f035a5b445edec4"
   integrity sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==
 
+object-is@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
+  integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -8242,6 +8972,18 @@ object.assign@^4.1.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.assign@^4.1.4:
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.7.tgz#8c14ca1a424c6a561b0bb2a22f66f5049a945d3d"
+  integrity sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
+    has-symbols "^1.1.0"
+    object-keys "^1.1.1"
 
 object.entries@^1.1.0, object.entries@^1.1.1:
   version "1.1.1"
@@ -8470,6 +9212,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
@@ -8563,6 +9310,13 @@ parse5@^3.0.1:
   dependencies:
     "@types/node" "*"
 
+parse5@^7.1.2:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
@@ -8625,6 +9379,14 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
 path-to-regexp@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
@@ -8655,6 +9417,16 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
 pbkdf2@^3.0.3, pbkdf2@^3.1.5:
   version "3.1.6"
@@ -9502,6 +10274,15 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -9629,6 +10410,11 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 q@^1.1.2:
   version "1.5.1"
@@ -9789,6 +10575,11 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-i
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -10126,6 +10917,18 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
+regexp.prototype.flags@^1.5.1:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
+  integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-errors "^1.3.0"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    set-function-name "^2.0.2"
+
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
@@ -10421,6 +11224,16 @@ rollup@^4.20.0:
     "@rollup/rollup-win32-x64-msvc" "4.62.4"
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz#c73451a484b86dd7cfb1e0b2898df4b703183e4b"
+  integrity sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==
+
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
 rst-selector-parser@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
@@ -10470,6 +11283,15 @@ safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1,
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
+safe-regex-test@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz#7f87dfb67a3150782eaaf18583ff5d1711ac10c1"
+  integrity sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    is-regex "^1.2.1"
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -10477,7 +11299,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -10536,6 +11358,13 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
+
 scheduler@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
@@ -10592,6 +11421,11 @@ semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.5.3, semver@^7.5.4:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@~0.19.0, send@~0.19.1:
   version "0.19.2"
@@ -10655,6 +11489,16 @@ set-function-length@^1.2.2:
     function-bind "^1.1.2"
     get-intrinsic "^1.2.4"
     gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
+
+set-function-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.2.tgz#16a705c5a0dc2f5e638ca96d8a8cd4e1c2b90985"
+  integrity sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
 
 set-value@^2.0.0, set-value@^2.0.1:
@@ -10779,7 +11623,7 @@ side-channel@^1.0.2:
     es-abstract "^1.17.0-next.1"
     object-inspect "^1.7.0"
 
-side-channel@^1.1.1:
+side-channel@^1.0.4, side-channel@^1.1.0, side-channel@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
   integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
@@ -10790,10 +11634,20 @@ side-channel@^1.1.1:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -10893,7 +11747,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.0, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -11033,6 +11887,11 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -11051,10 +11910,23 @@ statuses@~2.0.1, statuses@~2.0.2:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
   integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
+std-env@^3.8.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
+
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+stop-iteration-iterator@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
+  integrity sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==
+  dependencies:
+    es-errors "^1.3.0"
+    internal-slot "^1.1.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -11109,6 +11981,15 @@ string-length@^3.1.0:
     astral-regex "^1.0.0"
     strip-ansi "^5.2.0"
 
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -11144,14 +12025,14 @@ string-width@^4.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
   dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string.prototype.matchall@^4.0.2:
   version "4.0.2"
@@ -11221,6 +12102,13 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@6.0.0, strip-ansi@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
@@ -11249,12 +12137,12 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
   dependencies:
-    ansi-regex "^5.0.1"
+    ansi-regex "^6.2.2"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -11346,7 +12234,7 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-symbol-tree@^3.2.2:
+symbol-tree@^3.2.2, symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
@@ -11415,6 +12303,15 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+test-exclude@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.2.tgz#482392077630bc57d5630c13abe908bb910dfc65"
+  integrity sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^10.4.1"
+    minimatch "^10.2.2"
+
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -11464,6 +12361,43 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinypool@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
+  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
+
+tldts-core@^6.1.86:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.86.tgz#a93e6ed9d505cb54c542ce43feb14c73913265d8"
+  integrity sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==
+
+tldts@^6.1.32:
+  version "6.1.86"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.86.tgz#087e0555b31b9725ee48ca7e77edc56115cd82f7"
+  integrity sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==
+  dependencies:
+    tldts-core "^6.1.86"
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -11541,6 +12475,13 @@ tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tough-cookie@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-5.1.2.tgz#66d774b4a1d9e12dc75089725af3ac75ec31bed7"
+  integrity sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==
+  dependencies:
+    tldts "^6.1.32"
+
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -11555,6 +12496,13 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
 
 ts-pnp@1.1.5, ts-pnp@^1.1.2:
   version "1.1.5"
@@ -11873,7 +12821,18 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vite@^5.4.0:
+vite-node@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.1.9.tgz#549710f76a643f1c39ef34bdb5493a944e4f895f"
+  integrity sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.7"
+    es-module-lexer "^1.5.4"
+    pathe "^1.1.2"
+    vite "^5.0.0"
+
+vite@^5.0.0, vite@^5.4.0:
   version "5.4.21"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
   integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
@@ -11883,6 +12842,32 @@ vite@^5.4.0:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.9.tgz#7d01ffd07a553a51c87170b5e80fea3da7fb41e7"
+  integrity sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+  dependencies:
+    "@vitest/expect" "2.1.9"
+    "@vitest/mocker" "2.1.9"
+    "@vitest/pretty-format" "^2.1.9"
+    "@vitest/runner" "2.1.9"
+    "@vitest/snapshot" "2.1.9"
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    debug "^4.3.7"
+    expect-type "^1.1.0"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.1"
+    tinypool "^1.0.1"
+    tinyrainbow "^1.2.0"
+    vite "^5.0.0"
+    vite-node "2.1.9"
+    why-is-node-running "^2.3.0"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -11904,6 +12889,13 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
@@ -11939,6 +12931,11 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 webpack-dev-middleware@^3.7.2:
   version "3.7.2"
@@ -12066,6 +13063,13 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
@@ -12075,6 +13079,19 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^6.4.1:
   version "6.5.0"
@@ -12094,12 +13111,33 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
+which-boxed-primitive@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz#d76ec27df7fa165f18d5808374a5fe23c29b176e"
+  integrity sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==
+  dependencies:
+    is-bigint "^1.1.0"
+    is-boolean-object "^1.2.1"
+    is-number-object "^1.1.1"
+    is-string "^1.1.1"
+    is-symbol "^1.1.1"
+
+which-collection@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.2.tgz#627ef76243920a107e7ce8e96191debe4b16c2a0"
+  integrity sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==
+  dependencies:
+    is-map "^2.0.3"
+    is-set "^2.0.3"
+    is-weakmap "^2.0.2"
+    is-weakset "^2.0.3"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which-typed-array@^1.1.16:
+which-typed-array@^1.1.13, which-typed-array@^1.1.16:
   version "1.1.22"
   resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
   integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
@@ -12125,6 +13163,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@~1.2.3:
   version "1.2.3"
@@ -12280,6 +13326,15 @@ worker-rpc@^0.1.0:
   dependencies:
     microevent.ts "~0.1.1"
 
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -12297,14 +13352,14 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -12341,12 +13396,22 @@ ws@^6.1.2, ws@^6.2.1:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^8.18.0:
+  version "8.21.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.2.tgz#e6976cfe96161d40420689a5f051378d11b0f0ce"
+  integrity sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xmlchars@^2.1.1:
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.1.1, xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==


### PR DESCRIPTION
Part of #57 (§4, toolchain modernization, PR-B). Migrates the runtime test suite from react-scripts/Jest 24 + Enzyme to **Vitest 2 + React Testing Library 12 + jsdom**. React stays on 16 (hence RTL 12). `react-scripts`, `enzyme` and `jest` remain in devDependencies — PR-C removes them.

## Numbers

| | Before (Jest/Enzyme) | After (Vitest/RTL) |
|---|---|---|
| Suites | 8 | 8 |
| Tests | 113 passed | 113 passed |
| Snapshot files | 4 (enzyme-to-json) | 4 (DOM) |

## Non-regression proofs

### 1. Test-name diff: empty
Full test names extracted from both runners' JSON reporters (`react-scripts test --json` on master, `vitest run --reporter=json` on this branch), sorted; `diff` of the two 113-line lists is **empty** — every `describe`/`it` is character-identical.

### 2. Coverage: per-file istanbul equal to the Jest baseline

| File | Statements | Branches | Functions | Lines |
|---|---|---|---|---|
| src/lib/Field/Field.js | 100% = 100% | 95.45% = 95.45% | 100% = 100% | 100% = 100% |
| src/lib/FieldError/FieldError.js | 100% = 100% | 92.3% = 92.3% | 100% = 100% | 100% = 100% |
| src/lib/FieldError/getErrorMessage.js | 100% = 100% | 100% = 100% | 100% = 100% | 100% = 100% |
| src/lib/Form/Context.js | 83.33% = 83.33% | 50% = 50% | 100% = 100% | 83.33% = 83.33% |
| src/lib/Form/Form.js | 97.82% = 97.82% | 69.23% = 69.23% | 100% = 100% | 100% = 100% |
| src/lib/Form/helpers.js | 100% = 100% | 100% = 100% | 100% = 100% | 100% = 100% |
| src/lib/Form/throttle.js | 100% = 100% | 81.81% = 81.81% | 100% = 100% | 100% = 100% |
| src/lib/a11y.js | 100% = 100% | 100% = 100% | 100% = 100% | 100% = 100% |

Global totals identical too (98.36 / 84.61 / 100 / 99.27). The 5 remaining baseline files (`src/lib/**/index.js` ×4, `Context.types.js`) are 0-statement re-export/typedef files (100% by vacuity in the Jest report); the vitest istanbul provider omits them from the report — no metric is hidden by their absence.

### 3. Mutation bites (1 probe per zone, applied then reverted, targeted test run in between)

| Zone | Mutation | Failing test (reason) |
|---|---|---|
| ARIA gate (Field.js) | `revealed = true` | `should not expose aria-invalid nor aria-describedby while untouched and unsubmitted, even if invalid` → `expected true to be false` (attribute leaked on pristine form; 9 tests fail in total) |
| FieldError registry (Form.js) | `unregisterFieldError` no longer deletes | `should drop the id of an unmounted FieldError from aria-describedby` → stale id kept in IDREF list; registry-size test fails too |
| resetOnSubmit (Form.js) | condition inverted | both `resetOnSubmit prop` tests fail symmetrically (`[] ≠ ['type']`) |
| formatErrors (helpers.js) | bracket→dot regex loses `/g` | `should convert every array index when the path contains several` → `'items.0.tags[1]' ≠ 'items.0.tags.1'` |
| throttle (throttle.js) | trailing args dropped | `should coalesce calls…` → `expected "spy" to be called 2 times, but got 1 times` |

### 4. Builds and lint
- `yarn dist` ✅ and `yarn build` (Vite demo) ✅.
- `npx eslint src vitest.config.js`: **3 errors, all pre-existing** in `src/demo` (master has 11: the migration removes the 2 `setupTests` enzyme-import errors and the 6 `jest/no-test-callback` errors in `helpers.test.js`).

### 5. Stability
`CI=true yarn test:runtime` run twice back-to-back: 8/8 suites, 113/113 tests both times (per-file isolation kept at Vitest defaults).

## Notable port choices
- **`wrapper.instance()` / `wrapper.state()`** → `React.createRef()` on `<Form>` (the default export is the class at runtime; the polymorphic cast is JSDoc-only). Assertions mapped 1:1, `fieldErrorsVersion`/`fieldErrorRegistry` included — deliberately NOT rewritten "behaviorally" (that is the dom-first RFC's job, not this PR's).
- **DOM snapshots** replace enzyme-to-json ones; each new snapshot was re-read against the old one and represents the same rendered DOM (e.g. `noValidate={true}` prop → `novalidate=""` attribute, `onSubmit={[Function]}` is a listener and rightfully absent from DOM).
- **aria prop vs attribute semantics** reviewed one by one: prop `true` → attribute `'true'`, prop `false` → attribute `'false'` (React renders booleans as strings for aria-*), prop `undefined` → `hasAttribute() === false`. Tests that asserted both the React prop and the DOM attribute now assert the DOM form once.
- **React 16 event pooling**: with real DOM dispatch (fireEvent), synthetic events are nullified after the handler returns, so the two `Field` change tests capture `target.name/value` (and the second callback arg) at call time inside the spy implementation instead of inspecting the mock's recorded event afterwards. Same semantics, pooling-safe.
- **`done` callbacks** (unsupported by Vitest) in `helpers.test.js` → `vi.fn` handlers with the original `expect`s kept inside, plus `expect(handler).toHaveBeenCalled()` replacing the `done()` guarantee.
- **checkbox/radio change**: `fireEvent.click` (React 16 listens to click for these inputs); text/number/file keep `fireEvent.change`.
- **Mock choreography** (`Consumer.mockImplementationOnce` chains) unchanged; `vi.mock('../Form/Context')` resolves the adjacent `__mocks__` automatically. `scrollIntoView` probe keeps `mock.instances` (supported by Vitest for `this`-tracking, verified).

## Deviations (both minimal, both justified)
1. **Two comment-only source edits**: `/* istanbul ignore next */` → `/* istanbul ignore next -- @preserve */` in `Form.js` and `getErrorMessage.js`. esbuild (Vitest's transform) drops non-legal comments before istanbul instruments the code, which un-ignored the `REACT_APP_JFV_DEBUG` debug branches and regressed coverage (getErrorMessage 83.33% vs 100%). `@preserve` makes the comment "legal" for esbuild while istanbul still matches its prefix — both properties verified empirically. No executable code touched.
2. **`istanbul-lib-coverage@^3` added as a direct devDependency**: jest 24 hoists istanbul-lib-coverage 2 at the root, so `@vitest/coverage-istanbul` and `istanbul-lib-source-maps` each got their own nested v3 copy; the cross-copy `instanceof CoverageMap` check made report generation crash (`Invalid file coverage object`). Hoisting one shared v3 copy fixes it; the jest packages keep nested v2 copies. Becomes removable with PR-C.
3. **CI workflow (`.github/workflows/ci.yml`)**: both install steps drop `--ignore-optional`. The flag dates from the CRA-era CI (#54) when optional dependencies were convenience-only (fsevents…), but Rollup 4 — Vite/Vitest's runtime — ships its per-platform native binaries as `optionalDependencies`; skipping them crashed vitest on CI with `Cannot find module @rollup/rollup-linux-x64-gnu`. The lockfile already pins all `@rollup/rollup-*` platform packages, so installs stay deterministic. Removed from both jobs (the types job doesn't run rollup today, but the flag no longer has a reason to exist and PR-C runs Vite tooling everywhere).
