### PR TITLE
feat(form)!: upgrade bundled validator to AJV 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,12 @@ and dependency-only bumps are omitted.
     must call `addFormats(ajv)` themselves if they rely on formats.
   - The default instance is created with `strict: false`, keeping AJV 6's
     permissive behavior (unknown keywords compile instead of throwing).
-    Pass your own instance via the `ajv` prop for strict mode.
+    One safety net is lost in the process: AJV 6 threw at compile time on
+    an unknown **format name** (a typo like `format: 'emial'` crashed
+    immediately), whereas AJV 8 with `strict: false` only logs a warning
+    and ignores the format — every value then passes silently. Pass your
+    own strict-mode instance via the `ajv` prop to restore
+    compile-time typo detection.
   - A custom instance passed through the `ajv` prop should now be AJV 8+.
     AJV 6 instances keep working for the transition thanks to the
     `dataPath` fallback, which is deprecated and will be removed in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ and dependency-only bumps are omitted.
 
 ## [Unreleased]
 
+### Breaking
+
+- **AJV upgraded from v6 to v8** (`ajv@^8.17.0`). No code change is needed
+  if you only pass `schema`/`data` and read errors through `<FieldError>`
+  or `error.field`. Otherwise, see the "Migrating to v1 (AJV 8)" section
+  of the README. In short:
+  - Raw errors now carry the AJV 8 shape: `instancePath` (JSON Pointer,
+    e.g. `/user/email`) replaces `dataPath` (`.user.email`). The
+    normalized `field` property (`user.email`) is unchanged.
+  - Default error message wording changed in AJV 8 (`should …` →
+    `must …`, e.g. `must have required property 'email'`). Code or tests
+    matching on default messages must be updated; the `errorMessages`
+    prop (keyed by `error.keyword`) is immune.
+  - String formats (`email`, `date`, `uri`…) now come from the new
+    `ajv-formats` dependency (AJV 8 removed them from core), registered
+    on the default instance in its default `full` mode — stricter than
+    AJV 6 on some edge values, so a few borderline strings that used to
+    pass may now be rejected. Custom instances passed via the `ajv` prop
+    must call `addFormats(ajv)` themselves if they rely on formats.
+  - The default instance is created with `strict: false`, keeping AJV 6's
+    permissive behavior (unknown keywords compile instead of throwing).
+    Pass your own instance via the `ajv` prop for strict mode.
+  - A custom instance passed through the `ajv` prop should now be AJV 8+.
+    AJV 6 instances keep working for the transition thanks to the
+    `dataPath` fallback, which is deprecated and will be removed in the
+    final 1.0.
+  - The `ajv` prop is now duck-typed (any object exposing a
+    `compile(schema)` function) instead of `instanceOf(Ajv)`: `Ajv2019` /
+    `Ajv2020` instances — e.g. for JSON Schema draft 2020-12 — are
+    accepted.
+
 ### Changed
 
 - The npm package is now built with Vite (Rollup) instead of Babel CLI.
@@ -41,12 +72,10 @@ and dependency-only bumps are omitted.
 
 - Error formatting now understands both AJV error shapes: the AJV 8+
   `instancePath` (JSON Pointer, RFC 6901 — including `~0`/`~1` escape
-  decoding) in addition to the AJV 6 `dataPath` used by the bundled
-  validator. Behavior with the bundled AJV 6 is strictly unchanged;
-  this prepares the AJV 8 upgrade and custom validators that emit
-  JSON Pointer paths. The conversion lives in a new internal
-  `pointerToFieldPath(pointer)` helper (groundwork for AJV 8; not
-  part of the public API).
+  decoding) in addition to the legacy AJV 6 `dataPath` (kept as a
+  deprecated fallback for injected AJV 6 instances, see Breaking above).
+  The conversion lives in a new internal `pointerToFieldPath(pointer)`
+  helper (not part of the public API).
 - `resetOnSubmit` prop on `<Form>` — set it to `false` to keep the
   touched/submitted state after a successful submit (useful when the
   server-side submit can still fail), then call the context's `reset()`

--- a/README.md
+++ b/README.md
@@ -317,6 +317,11 @@ required. Otherwise:
 - **The default instance keeps AJV 6's permissive behavior** — it is created
   with `new Ajv({ allErrors: true, $data: true, strict: false })`:
   schemas containing unknown keywords still compile instead of throwing.
+  Note that this loses one AJV 6 safety net: AJV 6 threw at compile time on
+  an unknown format name (a typo like `format: 'emial'` crashed
+  immediately), while AJV 8 with `strict: false` only logs a warning and
+  ignores the format — every value then passes silently, so double-check
+  your format names (or use a strict instance, below).
   To opt into AJV 8 strict mode — or another JSON Schema draft — pass your
   own instance through the `ajv` prop. Any object exposing a
   `compile(schema)` function is accepted (`Ajv`, `Ajv2019`, `Ajv2020`…):

--- a/README.md
+++ b/README.md
@@ -290,6 +290,58 @@ import type {
 } from 'react-jsonschema-form-validation';
 ```
 
+## Migrating to v1 (AJV 8)
+
+Version 1.0 upgrades the bundled validator from AJV 6 to
+[AJV 8](https://ajv.js.org/v6-to-v8-migration.html). If you only pass
+`schema`/`data` and read errors through `<FieldError>`, no code change is
+required. Otherwise:
+
+- **`errors[].dataPath` → `errors[].instancePath`** — AJV 8 errors carry a
+  JSON Pointer `instancePath` (`/user/email`) instead of the dot-notation
+  `dataPath` (`.user.email`). The normalized `field` property added by the
+  library (`user.email`) is unchanged — code reading `error.field` keeps
+  working as-is. Code reading the raw `error.dataPath` must switch to
+  `error.instancePath`.
+- **Error message wording changed** — AJV 8 says `must be ...` where AJV 6
+  said `should be ...` (e.g. `must have required property 'email'`). If you
+  match on default AJV messages (tests, custom logic), update the wording —
+  or rather map messages by `error.keyword` via the `errorMessages` prop,
+  which is immune to wording changes.
+- **String formats now come from `ajv-formats`** — AJV 8 removed built-in
+  formats (`email`, `date`, `uri`…). The default instance restores them via
+  [`ajv-formats`](https://github.com/ajv-validator/ajv-formats) (a
+  dependency of this library), in its default `full` validation mode, which
+  is stricter than AJV 6's on some edge values. If you pass a custom `ajv`
+  instance and rely on formats, call `addFormats(ajv)` yourself.
+- **The default instance keeps AJV 6's permissive behavior** — it is created
+  with `new Ajv({ allErrors: true, $data: true, strict: false })`:
+  schemas containing unknown keywords still compile instead of throwing.
+  To opt into AJV 8 strict mode — or another JSON Schema draft — pass your
+  own instance through the `ajv` prop. Any object exposing a
+  `compile(schema)` function is accepted (`Ajv`, `Ajv2019`, `Ajv2020`…):
+
+  ```js
+  import Ajv2020 from 'ajv/dist/2020';
+  import addFormats from 'ajv-formats';
+
+  const ajv = new Ajv2020({ allErrors: true, $data: true }); // strict by default
+  addFormats(ajv);
+
+  <Form ajv={ajv} schema={schema} data={data} onSubmit={handleSubmit} />
+  ```
+
+- **Custom AJV 6 instances still work for now** — the library still
+  understands `dataPath`-shaped errors, so an injected AJV 6 instance keeps
+  functioning during the transition. This fallback is deprecated and will be
+  removed in the final 1.0.
+
+## Known limitations
+
+- Property names containing a dot (`.`) or a slash (`/`) are not supported
+  in field `name`s: the library addresses fields with dot-separated paths
+  (`user.email`), so such keys cannot be addressed unambiguously.
+
 ## Examples
 We’ve got many examples, from the most simple to the most advanced.
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
 	"repository": "github:53js/react-jsonschema-form-validation",
 	"dependencies": {
 		"@types/json-schema": "^7.0.15",
-		"ajv": "^6.11.0",
+		"ajv": "^8.17.0",
+		"ajv-formats": "^3",
 		"classnames": "^2.2.6",
 		"dot-prop-immutable": "^2.1.0",
 		"memoize-one": "^5.1.1",

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -599,7 +599,9 @@ Form.propTypes = {
 					propName,
 					'` supplied to `',
 					componentName,
-					'`: expected an AJV-like instance exposing a `compile()` function.',
+					'`: expected an AJV-like instance exposing a `compile()` function, received ',
+					typeof value,
+					'.',
 				),
 			);
 		}

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -6,6 +6,7 @@
  *   FormHTMLAttributes,
  *   ComponentProps,
  * } from 'react'
+ * @import Ajv from 'ajv'
  * @import { JSONSchema7Definition } from 'json-schema'
  * @import { FormattedError, FormChangeEvent, SafePropsOmit } from './helpers'
  * @import { ErrorMessagesMap } from './Context.types'
@@ -37,7 +38,6 @@
  * }} JfvScrollOptions
  */
 
-import Ajv from 'ajv';
 import classnames from 'classnames';
 import memoize from 'memoize-one';
 import React, { PureComponent } from 'react';
@@ -59,7 +59,7 @@ import {
  * with the props of the underlying component `C` and typed data `T`.
  *
  * @typedef {{
- *   ajv?: Ajv.Ajv,
+ *   ajv?: Ajv,
  *   children?: ReactNode,
  *   className?: string,
  *   component?: ElementType,
@@ -246,7 +246,7 @@ class Form extends PureComponent {
 	}))
 
 	memoGetValidator = memoize((
-		/** @type {Ajv.Ajv} */ ajv,
+		/** @type {Ajv} */ ajv,
 		/** @type {JSONSchema7Definition} */ schema,
 		/** @type {number} */ throttleDuration,
 	) => {
@@ -575,7 +575,36 @@ class Form extends PureComponent {
 }
 
 Form.propTypes = {
-	ajv: PropTypes.instanceOf(Ajv),
+	// Duck-typed on purpose (instead of `PropTypes.instanceOf(Ajv)`): any
+	// object exposing a `compile(schema)` function is accepted, so consumers
+	// can pass an `Ajv2019`/`Ajv2020` instance — or any compatible validator —
+	// without being tied to the exact Ajv class this library bundles.
+	ajv: (
+		/** @type {Record<string, unknown>} */ props,
+		/** @type {string} */ propName,
+		/** @type {string} */ componentName,
+	) => {
+		// A propTypes validator receives the whole props bag positionally —
+		// the indexed access is the documented PropTypes contract, not a
+		// component reading its own props.
+		// eslint-disable-next-line react/destructuring-assignment
+		const value = /** @type {{ compile?: unknown } | null | undefined} */ (props[propName]);
+		if (value == null) return null;
+		if (typeof value.compile !== 'function') {
+			// `String#concat` instead of a template literal: escaped backticks
+			// around `${...}` crash the template-curly-spacing rule under
+			// babel-eslint 10 / ESLint 6 (same quirk as in vite.lib.config.js).
+			return new Error(
+				'Invalid prop `'.concat(
+					propName,
+					'` supplied to `',
+					componentName,
+					'`: expected an AJV-like instance exposing a `compile()` function.',
+				),
+			);
+		}
+		return null;
+	},
 	children: PropTypes.node,
 	className: PropTypes.string,
 	component: PropTypes.elementType,

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -876,11 +876,36 @@ describe('AJV 8 integration', () => {
 		expect(error.message).toContain(
 			'expected an AJV-like instance exposing a `compile()` function',
 		);
+		// The message names the received type to speed up debugging.
+		expect(error.message).toContain('received object');
+		expect(validator({ ajv: 42 }, 'ajv', 'Form').message).toContain('received number');
 
 		// The prop stays optional…
 		expect(validator({}, 'ajv', 'Form')).toBeNull();
 		// …and any compile-capable object passes.
 		expect(validator({ ajv: { compile: () => {} } }, 'ajv', 'Form')).toBeNull();
+	});
+
+	it('should log the PropTypes error through console.error when rendering with a broken ajv prop', () => {
+		// End-to-end PropTypes proof: the warning is logged during render,
+		// BEFORE the mount-time validation crashes in `ajv.compile()` — the
+		// crash is expected (PropTypes only warns) and asserted as such.
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(() => {
+			render(
+				<Form
+					ajv={42}
+					onSubmit={() => {}}
+					schema={{}}
+				/>,
+			);
+		}).toThrow();
+
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('expected an AJV-like instance exposing a `compile()` function, received number'),
+		);
+		consoleErrorSpy.mockRestore();
 	});
 
 	it('should work with a real draft 2020-12 Ajv instance passed through the ajv prop', () => {

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -1,3 +1,4 @@
+import Ajv2020 from 'ajv/dist/2020';
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
@@ -700,6 +701,216 @@ describe('Form.touch(fieldName)', () => {
 		expect(ref.current.state.touchedFields).toEqual(['type', 'name']);
 		ref.current.touch('description');
 		expect(ref.current.state.touchedFields).toEqual(['type', 'name', 'description']);
+	});
+});
+
+describe('AJV 8 integration', () => {
+	it('should validate $data references through the form (password confirmation)', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				password: { type: 'string' },
+				confirm: { type: 'string', const: { $data: '1/password' } },
+			},
+		};
+
+		let ref = React.createRef();
+		render(
+			<Form
+				data={{ password: 's3cret', confirm: 'nope' }}
+				onSubmit={() => {}}
+				ref={ref}
+				schema={schema}
+			/>,
+		);
+
+		const errors = ref.current.getFieldErrors('confirm');
+		expect(errors.length).toStrictEqual(1);
+		expect(errors[0].keyword).toStrictEqual('const');
+
+		ref = React.createRef();
+		render(
+			<Form
+				data={{ password: 's3cret', confirm: 's3cret' }}
+				onSubmit={() => {}}
+				ref={ref}
+				schema={schema}
+			/>,
+		);
+		expect(ref.current.state.valid).toBe(true);
+	});
+
+	it('should report a format error for an invalid email (ajv-formats end-to-end)', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				email: { type: 'string', format: 'email' },
+			},
+		};
+
+		const ref = React.createRef();
+		render(
+			<Form
+				data={{ email: 'not-an-email' }}
+				onSubmit={() => {}}
+				ref={ref}
+				schema={schema}
+			/>,
+		);
+
+		const errors = ref.current.getFieldErrors('email');
+		expect(errors.length).toStrictEqual(1);
+		expect(errors[0].keyword).toStrictEqual('format');
+	});
+
+	it('should map a nested required error to the missing property path', () => {
+		// AJV 8 reports { instancePath: '/user', params: { missingProperty:
+		// 'email' } }: the formatted field must be 'user.email' so that
+		// <FieldError name="user.email"> and the a11y focus/scroll target
+		// the right input.
+		const schema = {
+			type: 'object',
+			properties: {
+				user: {
+					type: 'object',
+					properties: {
+						email: { type: 'string' },
+					},
+					required: ['email'],
+				},
+			},
+		};
+
+		const ref = React.createRef();
+		render(
+			<Form
+				data={{ user: {} }}
+				onSubmit={() => {}}
+				ref={ref}
+				schema={schema}
+			/>,
+		);
+
+		const errors = ref.current.getFieldErrors('user.email');
+		expect(errors.length).toStrictEqual(1);
+		expect(errors[0].keyword).toStrictEqual('required');
+	});
+
+	it('should map multi-index array errors to dotted field paths', () => {
+		// Real AJV 8 validation producing instancePath '/items/0/tags/1',
+		// which must land on the field path 'items.0.tags.1'.
+		const schema = {
+			type: 'object',
+			properties: {
+				items: {
+					type: 'array',
+					items: {
+						type: 'object',
+						properties: {
+							tags: {
+								type: 'array',
+								items: { type: 'string', minLength: 3 },
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const ref = React.createRef();
+		render(
+			<Form
+				data={{ items: [{ tags: ['okay', 'x'] }] }}
+				onSubmit={() => {}}
+				ref={ref}
+				schema={schema}
+			/>,
+		);
+
+		const errors = ref.current.getFieldErrors('items.0.tags.1');
+		expect(errors.length).toStrictEqual(1);
+		expect(errors[0].keyword).toStrictEqual('minLength');
+	});
+
+	it('should accept a duck-typed validator through the ajv prop (no PropTypes error)', () => {
+		// The `ajv` prop is duck-typed on `compile()` instead of
+		// `instanceOf(Ajv)`, so alternative validator classes (Ajv2019,
+		// Ajv2020…) are accepted. This fake instance also proves the fake's
+		// compile() is really what runs.
+		const compile = vi.fn(() => {
+			const validate = () => true;
+			validate.errors = null;
+			return validate;
+		});
+		const fakeAjv = { compile };
+
+		const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const ref = React.createRef();
+		render(
+			<Form
+				ajv={fakeAjv}
+				data={{ anything: 'goes' }}
+				onSubmit={() => {}}
+				ref={ref}
+				schema={{ type: 'object' }}
+			/>,
+		);
+
+		expect(compile).toHaveBeenCalledWith({ type: 'object' });
+		expect(ref.current.state.valid).toBe(true);
+		// No "Invalid prop `ajv`" PropTypes error was logged.
+		expect(consoleErrorSpy).not.toHaveBeenCalled();
+		consoleErrorSpy.mockRestore();
+	});
+
+	it('should reject a non-validator object passed as the ajv prop (PropTypes error)', () => {
+		// The custom validator is exercised directly: PropTypes only warns,
+		// so actually rendering with a broken instance would go on to crash
+		// in `ajv.compile()` anyway. Reading propTypes is safe here — the
+		// published build no longer strips them (see CHANGELOG).
+		// eslint-disable-next-line react/forbid-foreign-prop-types
+		const validator = Form.propTypes.ajv;
+
+		const error = validator({ ajv: { notCompile: true } }, 'ajv', 'Form');
+		expect(error).toBeInstanceOf(Error);
+		expect(error.message).toContain(
+			'expected an AJV-like instance exposing a `compile()` function',
+		);
+
+		// The prop stays optional…
+		expect(validator({}, 'ajv', 'Form')).toBeNull();
+		// …and any compile-capable object passes.
+		expect(validator({ ajv: { compile: () => {} } }, 'ajv', 'Form')).toBeNull();
+	});
+
+	it('should work with a real draft 2020-12 Ajv instance passed through the ajv prop', () => {
+		const ajv2020 = new Ajv2020({ allErrors: true });
+		const schema = {
+			type: 'object',
+			properties: {
+				// prefixItems is a 2020-12 keyword: the default draft-07
+				// instance would not apply it.
+				pair: {
+					type: 'array',
+					prefixItems: [{ type: 'string' }, { type: 'number' }],
+				},
+			},
+		};
+
+		const ref = React.createRef();
+		render(
+			<Form
+				ajv={ajv2020}
+				data={{ pair: ['label', 'not-a-number'] }}
+				onSubmit={() => {}}
+				ref={ref}
+				schema={schema}
+			/>,
+		);
+
+		const errors = ref.current.getFieldErrors('pair.1');
+		expect(errors.length).toStrictEqual(1);
+		expect(errors[0].keyword).toStrictEqual('type');
 	});
 });
 

--- a/src/lib/Form/helpers.js
+++ b/src/lib/Form/helpers.js
@@ -3,6 +3,7 @@
  */
 
 import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 import immutable from 'dot-prop-immutable';
 
 /**
@@ -11,11 +12,11 @@ import immutable from 'dot-prop-immutable';
  * `'items.0.label'`). Used everywhere internally to locate the input
  * associated with an error.
  *
- * `instancePath` is declared here because the bundled AJV 6 typings only
- * know `dataPath`; AJV 8 errors carry `instancePath` instead, and
+ * `dataPath` is declared here because the bundled AJV 8 typings only
+ * know `instancePath`; legacy AJV 6 errors carry `dataPath` instead, and
  * {@link formatErrors} accepts both shapes.
  *
- * @typedef {ErrorObject & { instancePath?: string, field: string }} FormattedError
+ * @typedef {ErrorObject & { dataPath?: string, field: string }} FormattedError
  */
 
 /**
@@ -72,23 +73,28 @@ import immutable from 'dot-prop-immutable';
  */
 
 /**
- * Returns a default AJV instance configured for use with the form.
+ * Returns a default AJV (v8) instance configured for use with the form:
+ * - `allErrors` — report every error, not just the first one, so all
+ *   invalid fields can be highlighted at once;
+ * - `$data` — enable `$data` references (e.g. password confirmation via
+ *   `const: { $data: '1/password' }`);
+ * - `strict: false` — keep AJV 6's permissive behavior: schemas with
+ *   unknown keywords or loose patterns compile instead of throwing.
+ *   Pass your own instance via the `ajv` prop for strict mode;
+ * - `ajv-formats` — restore the string formats (`email`, `date`, `uri`…)
+ *   that AJV 8 moved out of the core package.
  *
- * @returns {Ajv.Ajv}
+ * @returns {Ajv}
  */
-export const createAjv = () => new Ajv(
-	// Cast: the `v5` option no longer exists in AJV 6+ typings (it was a
-	// flag from AJV 3/4 that enabled draft-05 features, which became the
-	// default later). The runtime silently ignores unknown options. Kept
-	// here verbatim from the historical code so the lib stays byte-for-byte
-	// equivalent (notably for the Form snapshot test that captures AJV's
-	// internal `_opts` / `_metaOpts` state).
-	/** @type {Ajv.Options} */ ({
+export const createAjv = () => {
+	const ajv = new Ajv({
 		allErrors: true,
-		v5: true,
 		$data: true,
-	}),
-);
+		strict: false,
+	});
+	addFormats(ajv);
+	return ajv;
+};
 
 /**
  * Normalizes empty form values. Returns `undefined` for `''` and `null`
@@ -180,9 +186,10 @@ export const pointerToFieldPath = (pointer) => pointer
  * Accepts both AJV error shapes: when `error.instancePath` is present
  * (a JSON Pointer, AJV 8+) it takes precedence; otherwise the legacy
  * `error.dataPath` (dot/bracket notation, AJV ≤ 6) is used. The library
- * currently bundles AJV 6, so the `dataPath` branch is the active one —
- * the dual-shape support prepares the AJV 8 upgrade and is a building
- * block for a future Standard Schema adapter.
+ * bundles AJV 8, so the `instancePath` branch is the active one — the
+ * `dataPath` fallback is a soft landing for consumers who still inject a
+ * custom AJV 6 instance via the `ajv` prop (scheduled for removal in the
+ * final 1.0) and is a building block for a future Standard Schema adapter.
  *
  * @param {ErrorObject[] | null | undefined} errors
  * @returns {FormattedError[]}

--- a/src/lib/Form/helpers.test.js
+++ b/src/lib/Form/helpers.test.js
@@ -9,6 +9,41 @@ describe('.createAjv()', () => {
 		const ajv = helpers.createAjv();
 		expect(ajv).toBeInstanceOf(Ajv);
 	});
+
+	it('should compile and validate string formats (ajv-formats)', () => {
+		// AJV 8 moved formats out of the core package: without the
+		// `addFormats(ajv)` call in createAjv, `format: 'email'` would be
+		// silently ignored (strict: false) and every value would pass.
+		const ajv = helpers.createAjv();
+		const validate = ajv.compile({ type: 'string', format: 'email' });
+		expect(validate('hugo@53js.fr')).toBe(true);
+		expect(validate('not-an-email')).toBe(false);
+	});
+
+	it('should resolve $data references', () => {
+		// Password-confirmation pattern: `confirm` must equal the sibling
+		// `password` value. Requires the `$data: true` option.
+		const ajv = helpers.createAjv();
+		const validate = ajv.compile({
+			type: 'object',
+			properties: {
+				password: { type: 'string' },
+				confirm: { type: 'string', const: { $data: '1/password' } },
+			},
+		});
+		expect(validate({ password: 's3cret', confirm: 's3cret' })).toBe(true);
+		expect(validate({ password: 's3cret', confirm: 'nope' })).toBe(false);
+	});
+
+	it('should tolerate unknown keywords (strict mode disabled)', () => {
+		// AJV 8 defaults to strict mode, which throws on unknown keywords at
+		// compile time. createAjv keeps AJV 6's permissive behavior.
+		const ajv = helpers.createAjv();
+		expect(() => ajv.compile({
+			type: 'object',
+			someUnknownKeyword: true,
+		})).not.toThrow();
+	});
 });
 
 describe('.empty(value)', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,7 +1030,14 @@ agent-base@^7.1.0, agent-base@^7.1.2:
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0:
+ajv-formats@^3:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
+ajv@^6.10.0, ajv@^6.10.2:
   version "6.14.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.14.0.tgz#fd067713e228210636ebb08c60bd3765d6dbe73a"
   integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
@@ -1039,6 +1046,16 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.17.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ansi-escapes@^4.2.1:
   version "4.3.0"
@@ -2096,6 +2113,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2105,6 +2127,11 @@ fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-uri@^3.0.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fdir@^6.4.4, fdir@^6.5.0:
   version "6.5.0"
@@ -2816,6 +2843,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -3572,6 +3604,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary

PR 2 of the AJV track (targets **`v1`** — the 0.x line stays on AJV 6): the actual `ajv@^6.11.0` → `ajv@^8.17.0` bump, building on the dual-shape `formatErrors` landed in #78.

## Breaking changes

- **`ajv ^8.17.0`** (resolves to 8.20.0). Raw errors now carry `instancePath` (JSON Pointer) instead of `dataPath`; the normalized `field` property is unchanged, so consumers reading `error.field` (or using `<FieldError>`) need no change.
- **`ajv-formats ^3` added as a dependency** (published, external — not bundled): AJV 8 removed built-in string formats, and `format: 'email'` is this library's number-one use case — without it every such form would silently pass. Registered in its default `full` mode (stricter than AJV 6 on some edge values).
- **Default message wording** changed in AJV 8 (`should …` → `must …`).
- **`createAjv()`** now returns `new Ajv({ allErrors: true, $data: true, strict: false })` + `addFormats(ajv)`. `strict: false` preserves AJV 6's permissive behavior (unknown keywords compile instead of throwing); pass your own instance via the `ajv` prop for strict mode. The dead `v5` option and its obsolete comment are gone (the snapshot that justified it is DOM-only since #67).
- **`ajv` prop is now duck-typed** on `compile()` instead of `PropTypes.instanceOf(Ajv)` — `Ajv2019`/`Ajv2020` (draft 2020-12) instances are accepted (covered by tests, including a real `Ajv2020` + `prefixItems` run).
- **Soft landing kept**: the `dataPath` fallback in `formatErrors` remains, so injected custom AJV 6 instances keep working during the transition. Removal is scheduled for the final 1.0.

README gets a "Migrating to v1 (AJV 8)" section (dataPath→instancePath, wording, strict/2020-12 via the `ajv` prop with example) and a "Known limitations" note (keys containing `.` or `/` unsupported in `name`s). CHANGELOG `[Unreleased]` gets a detailed Breaking section.

## The "unchanged assertions" gate — proven

Baseline on `v1` (1e96295): **8 suites / 127 tests**. After the bump: **all 127 pre-existing tests pass without a single assertion modified** — that includes the 84 tests outside `helpers.test.js` (the gate) *and* the 43 helpers tests (the `dataPath` fallback tests still pass, since the fallback stays). Suite is green ×2 consecutive runs at **137/137** (127 + 10 new).

The only touch to a pre-existing test file other than additions: `Form.test.js` gains a new `describe('AJV 8 integration')` block and one import — zero existing lines modified.

## New tests (10) — each one's bite proven by mutation

| # | Test | Mutation that makes it fail (applied, observed red, reverted) |
|---|------|----------------------------------------------------------------|
| 1 | `createAjv` compiles + validates `format: 'email'` | remove `addFormats(ajv)` → 2 tests red |
| 2 | `createAjv` resolves `$data` refs | remove `$data: true` → 2 tests red |
| 3 | `createAjv` tolerates unknown keywords | remove `strict: false` → 1 test red |
| 4 | `<Form>` `$data` integration (password confirmation) — first `$data` coverage through the component | mutations 2 & 6 |
| 5 | `<Form>` email format end-to-end (keyword `format`) | mutations 1 & 6 |
| 6 | Nested `required` via real AJV 8 (`/user` + `missingProperty` → `user.email`, a11y path safety net) | bypass `pointerToFieldPath` → red |
| 7 | Multi-index real error (`/items/0/tags/1` → `items.0.tags.1`) | bypass `pointerToFieldPath` → red |
| 8 | Duck-typed `{ compile }` instance accepted, its `compile` really runs, no PropTypes error | route validator to `DEFAULT_AJV` → red |
| 9 | PropTypes validator rejects non-validator objects | neutralize the duck-type check → red |
| 10 | Real `Ajv2020` instance through the `ajv` prop (`prefixItems`) | route validator to `DEFAULT_AJV` → red |

Bonus signal: the `pointerToFieldPath` bypass mutation also turns 8 *pre-existing* Form tests red — the historical suite now exercises the AJV 8 `instancePath` path end-to-end.

## Verifications

- `yarn vitest run`: 137/137, green ×2
- `yarn lint`: clean (2 targeted eslint-disable with justification: propTypes-validator positional access; foreign-prop-types read in test)
- `yarn type-check`: clean
- `yarn test:types`: green on @types/react 16/17/18/19; regenerated `dist/index.d.ts` references AJV 8 types (`import Ajv from 'ajv'`, `ajv?: Ajv`)
- `yarn dist`: green; `dist/Form/helpers.js` imports `ajv-formats` as a **bare external import** (nothing bundled — the existing `vite.lib.config.js` external rule covers it, no config change needed)
- `npm publish --dry-run`: tarball builds clean (16 files, 64.1 kB unpacked); the final "cannot publish over 0.6.0" is the expected version-collision check — the version bump belongs to the release
- **Demo validated in a real browser** (build + preview + Playwright):
  - Basic form: `must match format "email"` (ajv-formats live), `must be equal to constant` on emailVerification (`$data`), `must be >= 18`, `must NOT have fewer than 1 items`, enum on CGU — all attached to the right fields, submit succeeds once fixed
  - Custom-error form: custom `minimum` ("You must be over 18") and `maximum` ("Damn, are you alive ? 100 is the limit") messages both triggered

## Scope

`package.json`, `yarn.lock`, `src/lib/Form/helpers.js`, `src/lib/Form/Form.js`, `src/lib/Form/helpers.test.js`, `src/lib/Form/Form.test.js` (additions only), `README.md`, `CHANGELOG.md`.