### PR TITLE
perf(form): skip validation dispatch on updates with unchanged inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,11 @@ and dependency-only bumps are omitted.
   identical `data` reference (and it is kept as defense in depth); the
   guard removes the redundant per-update dispatch. Validation still
   runs on mount and whenever `data`, `schema`, `ajv` or
-  `throttleDuration` changes.
+  `throttleDuration` changes. Note a pre-existing limitation this
+  change neither introduces nor fixes: mutating `data` in place and
+  re-rendering with the same reference has never triggered a
+  revalidation (the memoized validator already short-circuited on the
+  identical reference) — pass a new `data` object to revalidate.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ and dependency-only bumps are omitted.
   - The internal barrel files (`dist/Field/index.js`,
     `dist/FieldError/index.js`, `dist/Form/index.js`) are no longer
     emitted; they were never reachable through the `exports` map.
+- `<Form>` no longer dispatches a validation pass on re-renders where
+  none of the validation inputs (`data`, `schema`, `ajv`,
+  `throttleDuration`) changed by reference — e.g. the internal state
+  updates caused by touching a field, submitting, resetting, or the
+  `<FieldError>` id registry. Observable behavior is unchanged: the
+  memoized validator already short-circuited the actual AJV work on an
+  identical `data` reference (and it is kept as defense in depth); the
+  guard removes the redundant per-update dispatch. Validation still
+  runs on mount and whenever `data`, `schema`, `ajv` or
+  `throttleDuration` changes.
 
 ### Added
 

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -282,8 +282,33 @@ class Form extends PureComponent {
 		this.validate();
 	}
 
-	componentDidUpdate() {
-		this.validate();
+	/** @param {FormBaseProps} prevProps */
+	componentDidUpdate(prevProps) {
+		// Only re-validate when one of the validation inputs changed.
+		// Internal setState updates (touch, submit/isSubmitted, reset, the
+		// <FieldError> id registry…) re-render with the exact same props:
+		// dispatching validate() there is pure overhead — the memoized
+		// validator would short-circuit on the identical `data` reference
+		// anyway. The reference comparisons below use the same keys as
+		// `memoGetValidator` (ajv, schema, throttleDuration) plus the
+		// memoized `data` argument, so this guard skips exactly the updates
+		// the memoization already made no-ops. The memoize itself is kept as
+		// defense in depth (e.g. consecutive validations with the same data
+		// reference coming from the parent).
+		const {
+			ajv,
+			data,
+			schema,
+			throttleDuration,
+		} = this.props;
+		if (
+			prevProps.data !== data
+			|| prevProps.schema !== schema
+			|| prevProps.ajv !== ajv
+			|| prevProps.throttleDuration !== throttleDuration
+		) {
+			this.validate();
+		}
 	}
 
 	componentWillUnmount() {

--- a/src/lib/Form/Form.js
+++ b/src/lib/Form/Form.js
@@ -295,6 +295,15 @@ class Form extends PureComponent {
 		// the memoization already made no-ops. The memoize itself is kept as
 		// defense in depth (e.g. consecutive validations with the same data
 		// reference coming from the parent).
+		//
+		// Note: the comparisons rely on `Form.defaultProps` — React resolves
+		// `undefined` props to the module-level constants (DEFAULT_AJV,
+		// DEFAULT_DATA, DEFAULT_THROTTLE_DURATION) BEFORE this method runs,
+		// so the guard and `getValidator()` observe the same stable
+		// references. If defaultProps are ever removed (e.g. migrating off
+		// class components), the same destructuring fallbacks used in
+		// `getValidator()`/`validate()` must be applied to both `prevProps`
+		// and `this.props` here.
 		const {
 			ajv,
 			data,

--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -3,6 +3,7 @@ import { fireEvent, render } from '@testing-library/react';
 
 import Form from './Form';
 import Field from '../Field';
+import { createAjv } from './helpers';
 
 const testSchema = {
 	type: 'object',
@@ -700,6 +701,144 @@ describe('Form.touch(fieldName)', () => {
 		expect(ref.current.state.touchedFields).toEqual(['type', 'name']);
 		ref.current.touch('description');
 		expect(ref.current.state.touchedFields).toEqual(['type', 'name', 'description']);
+	});
+});
+
+describe('revalidation on update', () => {
+	// Wraps ajv.compile so every compiled validator counts its REAL
+	// invocations — measures actual AJV work, not only validate() dispatches
+	// (the memoized validator can short-circuit a dispatch without running
+	// AJV, so the two counters answer different questions).
+	const makeCountingAjv = () => {
+		const ajv = createAjv();
+		const counters = { compile: 0, run: 0 };
+		const realCompile = ajv.compile.bind(ajv);
+		ajv.compile = (schema) => {
+			counters.compile += 1;
+			const validate = realCompile(schema);
+			/** @param {object} data */
+			const wrapped = (data) => {
+				counters.run += 1;
+				const result = validate(data);
+				wrapped.errors = validate.errors;
+				return result;
+			};
+			wrapped.errors = null;
+			return wrapped;
+		};
+		return { ajv, counters };
+	};
+
+	it('should not dispatch validation on internal state updates with unchanged props (touch, submit)', () => {
+		const { ajv, counters } = makeCountingAjv();
+		const onSubmit = vi.fn();
+		const data = { type: 'te' };
+		const ref = React.createRef();
+
+		const { container } = render(
+			<Form
+				ajv={ajv}
+				data={data}
+				onSubmit={onSubmit}
+				ref={ref}
+				schema={testSchema}
+				throttleDuration={0}
+			/>,
+		);
+
+		// Mount validates once, unconditionally.
+		expect(counters.run).toBe(1);
+
+		const validateSpy = vi.spyOn(ref.current, 'validate');
+
+		// touch: internal setState, no prop changed → no validate() dispatch.
+		ref.current.touch('type');
+		// FieldError registry bump: same story.
+		ref.current.registerFieldError('key1', 'type', 'error-id-1');
+		// Submit on a never-touched-then-touched valid form: isSubmitted
+		// setState plus the default resetOnSubmit reset() — still no prop
+		// change. `valid` was computed at mount, so onSubmit must fire.
+		fireEvent.submit(container.querySelector('form'));
+
+		expect(onSubmit).toHaveBeenCalled();
+		// The guard skips the dispatch entirely…
+		expect(validateSpy).not.toHaveBeenCalled();
+		// …and no real AJV work happened either.
+		expect(counters.run).toBe(1);
+		expect(counters.compile).toBe(1);
+
+		validateSpy.mockRestore();
+	});
+
+	it('should re-validate when the data reference changes', () => {
+		const { ajv, counters } = makeCountingAjv();
+		const ref = React.createRef();
+
+		const formProps = {
+			ajv,
+			onSubmit: () => {},
+			ref,
+			schema: testSchema,
+			throttleDuration: 0,
+		};
+		const { rerender } = render(<Form data={{ type: 'te' }} {...formProps} />);
+		expect(counters.run).toBe(1);
+		expect(ref.current.state.valid).toBe(true);
+
+		// New data reference (nominal handleFieldChange → onChange → parent
+		// setState path) → the validator runs again on the new data.
+		rerender(<Form data={{ type: 'NOT_IN_ENUM' }} {...formProps} />);
+		expect(counters.run).toBe(2);
+		expect(ref.current.state.valid).toBe(false);
+	});
+
+	it('should re-compile and re-validate when the schema reference changes', () => {
+		const { ajv, counters } = makeCountingAjv();
+		const ref = React.createRef();
+
+		const formProps = {
+			ajv,
+			data: { type: 'te' },
+			onSubmit: () => {},
+			ref,
+			throttleDuration: 0,
+		};
+		const { rerender } = render(<Form schema={testSchema} {...formProps} />);
+		expect(counters.compile).toBe(1);
+		expect(counters.run).toBe(1);
+
+		// New schema reference → new compiled validator, immediate run.
+		rerender(<Form schema={{ ...testSchema, required: [] }} {...formProps} />);
+		expect(counters.compile).toBe(2);
+		expect(counters.run).toBe(2);
+	});
+
+	it('should re-validate when the ajv instance or throttleDuration changes', () => {
+		const first = makeCountingAjv();
+		const ref = React.createRef();
+
+		const formProps = {
+			data: { type: 'te' },
+			onSubmit: () => {},
+			ref,
+			schema: testSchema,
+		};
+		const { rerender } = render(
+			<Form ajv={first.ajv} throttleDuration={0} {...formProps} />,
+		);
+		expect(first.counters.run).toBe(1);
+
+		// New AJV instance → validator rebuilt on it and run.
+		const second = makeCountingAjv();
+		rerender(<Form ajv={second.ajv} throttleDuration={0} {...formProps} />);
+		expect(second.counters.compile).toBe(1);
+		expect(second.counters.run).toBe(1);
+
+		// New throttleDuration → throttled validator rebuilt and run.
+		rerender(<Form ajv={second.ajv} throttleDuration={1} {...formProps} />);
+		expect(second.counters.run).toBe(2);
+		// The first instance was never touched again.
+		expect(first.counters.run).toBe(1);
 	});
 });
 


### PR DESCRIPTION
Part of the final batch of audit #57 (§5, last item).

## Problem

`componentDidUpdate` dispatched `this.validate()` on **every** update — including re-renders caused by `<Form>`'s own `setState` (touch, submit/`isSubmitted`, `reset()`, the `<FieldError>` id registry) where none of the validation inputs changed.

## What instrumentation showed (before any fix)

Counting **real AJV runs** (wrapped `ajv.compile`) on master:

| Update | validate() dispatched | real AJV run |
|---|---|---|
| mount | yes | **1** (expected) |
| touch / registerFieldError / submit / reset (props unchanged) | yes, every time | **0** — the memoized validator short-circuits on the identical `data` reference |
| in-place mutation of `data` + re-render (same ref) | yes | **0** — already NOT caught before this PR (`state.valid` stays stale until the next reference change) |
| new `data` reference | yes | +1 |
| new `schema` reference | yes | +1 compile, +1 run |

So the redundant work on internal updates was the **dispatch machinery** (`getValidator()` + two memoize arg-comparisons per update), not AJV itself — the memoize already absorbed the AJV cost. This PR removes the dispatch too, and makes the contract explicit.

## Fix

Guard in `componentDidUpdate(prevProps)`: dispatch `validate()` only when `data`, `schema`, `ajv` or `throttleDuration` changed **by reference** — the exact keys the existing memoization (`memoGetValidator` + memoized `data` arg) is built on, so the guard skips exactly the updates the memoize already made no-ops. The memoize is **kept** as defense in depth. `componentDidMount` still validates unconditionally.

## Non-regressions checked explicitly

- **Nominal path** `handleFieldChange` → parent `onChange` → new `data` ref: still validates (`prevProps.data !== data`). Covered by test.
- **`reset()`**: already did NOT revalidate immediately on master (memoize hit) — post-reset state (`valid: true`, `errors: []`) is byte-identical before/after this PR, until the next real input change. Existing reset tests pass unchanged.
- **Submit on a never-touched form**: `valid` comes from the mount run; `onSubmit` fires correctly with zero extra AJV work. Covered by test.
- **In-place data mutation**: behavior unchanged (was already not revalidated — memoize hit; and `PureComponent` usually blocks the re-render anyway). Documented honestly rather than silently 'fixed'.

## Tests

4 added (127 → 131):
1. counter + spy test: internal updates (touch, register, submit) dispatch **zero** `validate()` calls and **zero** real AJV runs;
2. new `data` ref → revalidates (state updates);
3. new `schema` ref → recompiles + revalidates;
4. new `ajv` instance / `throttleDuration` → validator rebuilt + revalidates.

**Bite proved**: with the guard reverted, test 1 fails (`validate` dispatched 3 times). Honest note: the *AJV-run* counter alone would not bite — the memoize already blocked AJV runs on identical data; the bite is on the dispatch spy, which is precisely what the guard changes.

**Gate**: all 127 pre-existing tests pass **without any assertion modified** (run twice). Lint clean, type-level tests green on @types/react 16–19.