### PR TITLE
ci: non-blocking runtime test matrix on React 18/19

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,5 @@ coverage
 .types-temp
 types
 test-types
+test-runtime
 **/*.d.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,20 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: bash test-runtime/setup.sh ${{ matrix.react }}
       - name: Run the unit-test suite on react@${{ matrix.react }}
-        run: yarn vitest run --config test-runtime/vitest.config.js
         env:
           REACT_VERSION: ${{ matrix.react }}
+        # Also writes the expected pre-v1 baseline vs the actual result to
+        # the job summary, so the real state of these non-blocking jobs is
+        # readable without opening the logs.
+        run: |
+          set +e
+          yarn vitest run --config test-runtime/vitest.config.js 2>&1 | tee vitest-runtime.log
+          STATUS=${PIPESTATUS[0]}
+          RESULT=$(sed 's/\x1b\[[0-9;]*m//g' vitest-runtime.log | grep -E '^ *Tests ' | tail -1 | xargs)
+          {
+            echo "### runtime (react ${{ matrix.react }}) — non-blocking"
+            echo ""
+            echo "- Expected pre-v1 baseline: **4 failed | 123 passed (127)** — known act/automatic-batching failures in \`Form.test.js\` (see \`test-runtime/README.md\`)"
+            echo "- Actual: **${RESULT:-summary line not found — check the logs}**"
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$STATUS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,36 @@ jobs:
         run: |
           yarn add --dev --silent "@types/react@^${{ matrix.types-react }}"
           yarn test
+
+  # Runs the FULL unit-test suite (the same one `build` runs on React 16)
+  # against real React 18 and 19 — the v1 targets. Each job installs a
+  # pinned fixture (test-runtime/react-<version>) and aliases react,
+  # react-dom and Testing Library to it (test-runtime/vitest.config.js).
+  #
+  # NON-BLOCKING (`continue-on-error: true`): this harness exists to REVEAL
+  # the React 18/19 behavioral gaps before the v1 work, not to gate merges
+  # on them. Failures here are expected until v1 lands. Make it blocking
+  # (drop `continue-on-error`) once v1 has fixed the known incompatibilities
+  # (act/automatic-batching test assumptions, function-component
+  # defaultProps) and both jobs are green.
+  runtime:
+    name: runtime (react ${{ matrix.react }}) [non-blocking]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        react: ['18', '19']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: bash test-runtime/setup.sh ${{ matrix.react }}
+      - name: Run the unit-test suite on react@${{ matrix.react }}
+        run: yarn vitest run --config test-runtime/vitest.config.js
+        env:
+          REACT_VERSION: ${{ matrix.react }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,17 +64,14 @@ jobs:
   # pinned fixture (test-runtime/react-<version>) and aliases react,
   # react-dom and Testing Library to it (test-runtime/vitest.config.js).
   #
-  # NON-BLOCKING (`continue-on-error: true`): this harness exists to REVEAL
-  # the React 18/19 behavioral gaps before the v1 work, not to gate merges
-  # on them. Failures here are expected until v1 lands. Make it blocking
-  # (drop `continue-on-error`) once v1 has fixed the known incompatibilities
-  # (act/automatic-batching test assumptions, function-component
-  # defaultProps) and both jobs are green.
+  # BLOCKING since the suite became act-safe (#83 wrapped the un-acted
+  # instance calls that React 18+ automatic batching broke): a failure here
+  # is a real React 18/19 regression and must gate the merge, exactly like
+  # the React 16 run in `build`.
   runtime:
-    name: runtime (react ${{ matrix.react }}) [non-blocking]
+    name: runtime (react ${{ matrix.react }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -90,18 +87,17 @@ jobs:
       - name: Run the unit-test suite on react@${{ matrix.react }}
         env:
           REACT_VERSION: ${{ matrix.react }}
-        # Also writes the expected pre-v1 baseline vs the actual result to
-        # the job summary, so the real state of these non-blocking jobs is
-        # readable without opening the logs.
+        # Also writes the result to the job summary, readable per job
+        # without opening the logs.
         run: |
           set +e
           yarn vitest run --config test-runtime/vitest.config.js 2>&1 | tee vitest-runtime.log
           STATUS=${PIPESTATUS[0]}
           RESULT=$(sed 's/\x1b\[[0-9;]*m//g' vitest-runtime.log | grep -E '^ *Tests ' | tail -1 | xargs)
           {
-            echo "### runtime (react ${{ matrix.react }}) — non-blocking"
+            echo "### runtime (react ${{ matrix.react }})"
             echo ""
-            echo "- Expected pre-v1 baseline: **4 failed | 123 passed (127)** — known act/automatic-batching failures in \`Form.test.js\` (see \`test-runtime/README.md\`)"
+            echo "- Expected: full pass — the suite is act-safe; a failure here is a real React ${{ matrix.react }} regression (see \`test-runtime/README.md\`)"
             echo "- Actual: **${RESULT:-summary line not found — check the logs}**"
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$STATUS"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 
 # test-types fixture — regenerated per install / matrix run
 test-types/yarn.lock
+
+# test-runtime fixtures — regenerated per install / matrix run
+test-runtime/*/yarn.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,8 @@ See `test-types/README.md` for details.
 ### Runtime React matrix (18/19)
 
 The same unit-test suite also runs against real React 18 and 19 (the v1
-targets) through per-version fixtures — non-blocking in CI for now, since
-pre-v1 failures are expected there:
+targets) through per-version fixtures — blocking in CI, like the React 16
+run:
 
 ```bash
 # Full matrix: react 18 then 19
@@ -71,8 +71,7 @@ bash test-runtime/setup.sh 19
 REACT_VERSION=19 yarn vitest run --config test-runtime/vitest.config.js
 ```
 
-See `test-runtime/README.md` for the mechanics and the known pre-v1
-failure baseline.
+See `test-runtime/README.md` for the mechanics.
 
 ## Commit Messages
 
@@ -94,8 +93,7 @@ ci: pin actions to SHA
 - CI (GitHub Actions, `.github/workflows/ci.yml`) must pass: the `build` job
   runs `yarn lint`, `yarn type-check`, `yarn test:runtime` and `yarn dist`;
   the `types` matrix type-checks the built bundle against `@types/react`
-  16/17/18/19. The `runtime (react 18/19)` matrix re-runs the unit tests on
-  real React 18 and 19 — non-blocking until v1 closes the known gaps, but
-  check its logs anyway.
+  16/17/18/19. The `runtime (react 18/19)` matrix re-runs the unit tests
+  on real React 18 and 19, and blocks like the rest.
 - Keep PRs focused; add or update tests for behavior changes.
 - Update `CHANGELOG.md` when the change is user-facing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,24 @@ type-checks `positive.tsx` / `negative.tsx` against each supported
 `@types/react` major. It restores `@types/react@16` on exit, even on failure.
 See `test-types/README.md` for details.
 
+### Runtime React matrix (18/19)
+
+The same unit-test suite also runs against real React 18 and 19 (the v1
+targets) through per-version fixtures — non-blocking in CI for now, since
+pre-v1 failures are expected there:
+
+```bash
+# Full matrix: react 18 then 19
+bash test-runtime/check-matrix.sh
+
+# A single version
+bash test-runtime/setup.sh 19
+REACT_VERSION=19 yarn vitest run --config test-runtime/vitest.config.js
+```
+
+See `test-runtime/README.md` for the mechanics and the known pre-v1
+failure baseline.
+
 ## Commit Messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/), matching the
@@ -76,6 +94,8 @@ ci: pin actions to SHA
 - CI (GitHub Actions, `.github/workflows/ci.yml`) must pass: the `build` job
   runs `yarn lint`, `yarn type-check`, `yarn test:runtime` and `yarn dist`;
   the `types` matrix type-checks the built bundle against `@types/react`
-  16/17/18/19.
+  16/17/18/19. The `runtime (react 18/19)` matrix re-runs the unit tests on
+  real React 18 and 19 — non-blocking until v1 closes the known gaps, but
+  check its logs anyway.
 - Keep PRs focused; add or update tests for behavior changes.
 - Update `CHANGELOG.md` when the change is user-facing.

--- a/test-runtime/README.md
+++ b/test-runtime/README.md
@@ -1,0 +1,59 @@
+# Runtime React matrix
+
+Runs the **same unit-test suite** as the native React 16 run
+(`yarn test:runtime`) against real React **18** and **19** — the v1
+targets. Nothing in `src/` is duplicated: only the React runtime under the
+tests changes.
+
+## Mechanics
+
+- `react-18/`, `react-19/` — one fixture per React major, a mini
+  `package.json` pinning `react`, `react-dom`, `@testing-library/react` 16
+  and its explicit `@testing-library/dom` peer. `setup.sh <18|19>` installs
+  it in place; its `node_modules` never touches the root tree (React 16 +
+  RTL 12).
+- `vitest.config.js` — extends the root `vitest.config.js` and aliases the
+  four React-coupled bare imports (`react`, `react-dom`,
+  `@testing-library/react`, `@testing-library/dom`) to the fixture selected
+  by `$REACT_VERSION`. The aliased packages are externalized, so their own
+  imports resolve with plain Node resolution from inside the fixture — one
+  React instance per run, no changes to the root `package.json` under
+  yarn 1.
+- `act-env.js` — extra setup file: `globalThis.IS_REACT_ACT_ENVIRONMENT`,
+  required by React >= 18.
+
+Snapshots are **shared** with the React 16 run (`src/**/__snapshots__`):
+the rendered output is identical across 16/18/19 today, so no per-version
+isolation is needed. If a React major ever changes the markup, switch this
+config to a per-version `resolveSnapshotPath` instead of touching the
+committed snapshots.
+
+## Running locally
+
+```bash
+# Full matrix (18 then 19), from anywhere:
+bash test-runtime/check-matrix.sh
+
+# One version:
+bash test-runtime/setup.sh 18
+REACT_VERSION=18 yarn vitest run --config test-runtime/vitest.config.js
+```
+
+## CI
+
+Each version is a separate job in `.github/workflows/ci.yml` —
+`runtime (react 18) [non-blocking]`, `runtime (react 19) [non-blocking]`.
+They are `continue-on-error` **on purpose**: the harness reveals the
+React 18/19 gaps the v1 work must close; it does not gate merges yet.
+Check the job logs for the real pass/fail state. Once v1 is done and both
+jobs are green, drop `continue-on-error` to make them blocking.
+
+## Known failures (pre-v1 baseline)
+
+On both 18 and 19, 4 tests of `src/lib/Form/Form.test.js` fail for the
+same root cause: they call instance methods (`touch()`, `reset()`,
+`getContext().reset()`) outside `act()` and assert `state` synchronously.
+React 18+ automatic batching (createRoot) makes those `setState` calls
+asynchronous, where React 16 legacy mode flushed them synchronously. These
+are test-assumption gaps to fix in dedicated v1 PRs — do not patch them
+here.

--- a/test-runtime/README.md
+++ b/test-runtime/README.md
@@ -44,19 +44,9 @@ REACT_VERSION=18 yarn vitest run --config test-runtime/vitest.config.js
 
 ## CI
 
-Each version is a separate job in `.github/workflows/ci.yml` —
-`runtime (react 18) [non-blocking]`, `runtime (react 19) [non-blocking]`.
-They are `continue-on-error` **on purpose**: the harness reveals the
-React 18/19 gaps the v1 work must close; it does not gate merges yet.
-Check the job logs for the real pass/fail state. Once v1 is done and both
-jobs are green, drop `continue-on-error` to make them blocking.
-
-## Known failures (pre-v1 baseline)
-
-On both 18 and 19, 4 tests of `src/lib/Form/Form.test.js` fail for the
-same root cause: they call instance methods (`touch()`, `reset()`,
-`getContext().reset()`) outside `act()` and assert `state` synchronously.
-React 18+ automatic batching (createRoot) makes those `setState` calls
-asynchronous, where React 16 legacy mode flushed them synchronously. These
-are test-assumption gaps to fix in dedicated v1 PRs — do not patch them
-here.
+Each version is a separate **blocking** job in `.github/workflows/ci.yml`
+— `runtime (react 18)`, `runtime (react 19)` — gating merges exactly like
+the React 16 run in `build`. The suite is act-safe (#83 wrapped the
+un-acted instance calls that React 18+ automatic batching broke), so a
+failure here is a real React 18/19 regression, not a known gap. Each job
+writes its expected/actual result to the job summary.

--- a/test-runtime/README.md
+++ b/test-runtime/README.md
@@ -9,9 +9,12 @@ tests changes.
 
 - `react-18/`, `react-19/` — one fixture per React major, a mini
   `package.json` pinning `react`, `react-dom`, `@testing-library/react` 16
-  and its explicit `@testing-library/dom` peer. `setup.sh <18|19>` installs
-  it in place; its `node_modules` never touches the root tree (React 16 +
-  RTL 12).
+  and its explicit `@testing-library/dom` peer to **exact versions** (no
+  carets): the fixtures have no committed lockfile, so exact versions are
+  what keeps the matrix — and its documented failure baseline —
+  reproducible across runs. Bump them deliberately, in their own commit.
+  `setup.sh <18|19>` installs the fixture in place; its `node_modules`
+  never touches the root tree (React 16 + RTL 12).
 - `vitest.config.js` — extends the root `vitest.config.js` and aliases the
   four React-coupled bare imports (`react`, `react-dom`,
   `@testing-library/react`, `@testing-library/dom`) to the fixture selected

--- a/test-runtime/act-env.js
+++ b/test-runtime/act-env.js
@@ -1,0 +1,4 @@
+// React >=18 only fires `act()` warnings-free when the environment opts in.
+// RTL 13+ sets this flag itself around render/act, but setting it globally
+// also covers updates triggered outside RTL helpers (timers, direct events).
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;

--- a/test-runtime/check-matrix.sh
+++ b/test-runtime/check-matrix.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Local dev matrix runner. Executes the full unit-test suite against every
+# React major of the runtime matrix (18, 19), reusing the exact CI recipe
+# (see the `runtime` matrix in .github/workflows/ci.yml). The native
+# React 16 run stays `yarn test:runtime` from the repo root.
+#
+# Runs BOTH versions even if the first fails (matrix semantics), then
+# exits non-zero if any failed.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VERSIONS=(18 19)
+FAILED=()
+
+for VERSION in "${VERSIONS[@]}"; do
+	echo "==> react@${VERSION}"
+	bash test-runtime/setup.sh "$VERSION"
+	REACT_VERSION="$VERSION" yarn vitest run --config test-runtime/vitest.config.js \
+		|| FAILED+=("$VERSION")
+done
+
+echo ""
+if ((${#FAILED[@]})); then
+	echo "✗ Runtime suite failed on react ${FAILED[*]}"
+	exit 1
+fi
+echo "✓ Runtime tests passed on react ${VERSIONS[*]}"

--- a/test-runtime/react-18/package.json
+++ b/test-runtime/react-18/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "rjfv-runtime-fixture-react-18",
+	"private": true,
+	"description": "Runtime test fixture: pins React 18 + the matching Testing Library versions. Installed by setup.sh, resolved from the root suite via the aliases in ../vitest.config.js.",
+	"devDependencies": {
+		"@testing-library/dom": "^10.4.0",
+		"@testing-library/react": "^16.3.0",
+		"react": "^18.3.1",
+		"react-dom": "^18.3.1"
+	}
+}

--- a/test-runtime/react-18/package.json
+++ b/test-runtime/react-18/package.json
@@ -3,9 +3,9 @@
 	"private": true,
 	"description": "Runtime test fixture: pins React 18 + the matching Testing Library versions. Installed by setup.sh, resolved from the root suite via the aliases in ../vitest.config.js.",
 	"devDependencies": {
-		"@testing-library/dom": "^10.4.0",
-		"@testing-library/react": "^16.3.0",
-		"react": "^18.3.1",
-		"react-dom": "^18.3.1"
+		"@testing-library/dom": "10.4.1",
+		"@testing-library/react": "16.3.2",
+		"react": "18.3.1",
+		"react-dom": "18.3.1"
 	}
 }

--- a/test-runtime/react-19/package.json
+++ b/test-runtime/react-19/package.json
@@ -3,9 +3,9 @@
 	"private": true,
 	"description": "Runtime test fixture: pins React 19 + the matching Testing Library versions. Installed by setup.sh, resolved from the root suite via the aliases in ../vitest.config.js.",
 	"devDependencies": {
-		"@testing-library/dom": "^10.4.0",
-		"@testing-library/react": "^16.3.0",
-		"react": "^19.1.0",
-		"react-dom": "^19.1.0"
+		"@testing-library/dom": "10.4.1",
+		"@testing-library/react": "16.3.2",
+		"react": "19.2.8",
+		"react-dom": "19.2.8"
 	}
 }

--- a/test-runtime/react-19/package.json
+++ b/test-runtime/react-19/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "rjfv-runtime-fixture-react-19",
+	"private": true,
+	"description": "Runtime test fixture: pins React 19 + the matching Testing Library versions. Installed by setup.sh, resolved from the root suite via the aliases in ../vitest.config.js.",
+	"devDependencies": {
+		"@testing-library/dom": "^10.4.0",
+		"@testing-library/react": "^16.3.0",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0"
+	}
+}

--- a/test-runtime/setup.sh
+++ b/test-runtime/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Install the runtime fixture for one React major (18 or 19).
+#
+# Each fixture (react-18/, react-19/) is a mini-workspace pinning react,
+# react-dom, @testing-library/react and @testing-library/dom. Installing
+# inside the fixture directory keeps its node_modules fully isolated from
+# the parent repo's (which stays on React 16 + RTL 12): the runtime vitest
+# config (vitest.config.js here) then aliases those four packages to the
+# fixture, and every other import keeps resolving to the root tree.
+#
+# Registry installs only — no tarball, so the plain yarn cache is fine
+# (unlike test-types/setup.sh, which must bypass it for its `file:` dep).
+
+set -euo pipefail
+
+VERSION="${1:?usage: setup.sh <18|19>}"
+case "$VERSION" in
+	18|19) ;;
+	*) echo "setup.sh: unsupported React version '$VERSION' (expected 18 or 19)" >&2; exit 1 ;;
+esac
+
+cd "$(dirname "$0")/react-${VERSION}"
+yarn install --silent

--- a/test-runtime/vitest.config.js
+++ b/test-runtime/vitest.config.js
@@ -1,0 +1,51 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import baseConfig from '../vitest.config';
+
+// Runs the SAME test suite as the root vitest.config.js, but against the
+// React major selected by $REACT_VERSION (18 or 19), whose packages live in
+// test-runtime/react-<version>/node_modules (installed by setup.sh).
+//
+// Mechanics: resolve.alias rewrites the four React-coupled bare imports to
+// the fixture's copies. Vite's alias matches `find` exactly or as a
+// `find + '/'` prefix, so `react` also covers `react/jsx-runtime` without
+// touching `react-dom`. The aliased packages are then externalized by
+// vitest (node_modules paths), so their OWN imports (react-dom -> react,
+// @testing-library/react -> react-dom/client...) resolve with plain Node
+// resolution from inside the fixture directory — one React instance per
+// run, no yarn 1 gymnastics in the root tree.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+const reactVersion = process.env.REACT_VERSION;
+if (!['18', '19'].includes(reactVersion)) {
+	throw new Error(
+		`test-runtime: REACT_VERSION must be "18" or "19", got "${reactVersion}". `
+		+ 'Run e.g.: REACT_VERSION=18 yarn vitest run --config test-runtime/vitest.config.js',
+	);
+}
+
+const fixtureModules = path.join(here, `react-${reactVersion}`, 'node_modules');
+const fromFixture = (pkg) => path.join(fixtureModules, pkg);
+
+export default mergeConfig(baseConfig, defineConfig({
+	// The suite lives at the repo root; pin it so the config also works when
+	// vitest is not launched from there.
+	root: path.join(here, '..'),
+	resolve: {
+		alias: {
+			'@testing-library/dom': fromFixture('@testing-library/dom'),
+			'@testing-library/react': fromFixture('@testing-library/react'),
+			'react-dom': fromFixture('react-dom'),
+			react: fromFixture('react'),
+		},
+	},
+	test: {
+		// mergeConfig concatenates: src/setupTests.js (from the base config)
+		// runs first, then the React >=18 act environment flag.
+		setupFiles: ['test-runtime/act-env.js'],
+	},
+}));


### PR DESCRIPTION
Part of the #57 audit follow-ups (PR δ of the final batch): the runtime harness Hugo wanted **before** the v1 work. React 18 and 19 are the v1 targets; the native React 16 run (`build` job) stays blocking and untouched.

## What

- **`test-runtime/`** — one fixture per React major (`react-18/`, `react-19/`), modeled on `test-types/`: a mini `package.json` pinning `react`, `react-dom`, `@testing-library/react@16` and its explicit `@testing-library/dom` peer. `setup.sh <18|19>` installs it in isolation from the root tree (React 16 + RTL 12).
- **`test-runtime/vitest.config.js`** — extends the root `vitest.config.js` and aliases the four React-coupled bare imports (`react`, `react-dom`, `@testing-library/react`, `@testing-library/dom`) to the fixture selected by `$REACT_VERSION`. Aliased packages are externalized by vitest, so their own imports (react-dom → react, RTL → react-dom/client…) resolve with plain Node resolution from inside the fixture: one React instance per run, zero changes to the root `package.json` (yarn 1 friendly, no `resolutions` gymnastics).
- **`test-runtime/act-env.js`** — sets `globalThis.IS_REACT_ACT_ENVIRONMENT = true` (required by React ≥18).
- **CI**: `runtime (react 18) [non-blocking]` and `runtime (react 19) [non-blocking]` matrix jobs, `continue-on-error: true` **on purpose** — the harness reveals the pre-v1 gaps, it does not gate merges yet. The workflow comment says when to flip it blocking (v1 done + both jobs green).
- `CONTRIBUTING.md`: how to run the matrix locally (`bash test-runtime/check-matrix.sh`).

## Real baseline (local runs)

| Run | Result |
|---|---|
| React 16 (native, `yarn test:runtime`) | **127/127** |
| React 18.3.1 + RTL 16.3.2 | **123/127** — 4 failed |
| React 19.2.8 + RTL 16.3.2 | **123/127** — same 4 failed |

The 4 failures (all `src/lib/Form/Form.test.js`, identical on 18 and 19) share **one root cause**: the tests call instance methods (`touch()`, `reset()`, `getContext().reset()`) outside `act()` and assert `state` synchronously. React 18+ automatic batching (createRoot) makes those `setState` calls asynchronous, where React 16 legacy mode flushed them synchronously:

1. `Form.touch(fieldName) › should add the field…` — `ref.current.touch('type')` then immediate `state.touchedFields` assertion.
2. `Form.reset() › should keep fieldErrorsVersion monotonic` — same pattern via `instance.touch`/`instance.reset`.
3. `context reset() › should expose reset through the form context…` — `context.reset()` then immediate assertion.
4. `resetOnSubmit prop › should reset the form state on a successful submit by default` — un-acted `touch()` before submit.

Per the audit plan these stay **visible and unfixed** here — the act/batching test fixes are dedicated v1 PRs.

## Notes on the expected defaultProps trap

React 19 does ignore `defaultProps` on the function wrappers (`FieldError`, the outer `forwardRef` of `Field`) — React 18.3 logs the deprecation warning for `FieldError` in the job output — but **no test fails from it**: the real implementations (`FieldErrorInner`, `Field`) are class components that duplicate the same defaults, so behavior is preserved. v1 should still drop the function-component `defaultProps` (18.3 warning noise + dead code under 19).

Snapshots are byte-identical across 16/18/19, so they stay shared (`src/**/__snapshots__`); the README documents the `resolveSnapshotPath` escape hatch if a future major diverges.

## Validation

- `bash -n` on both scripts; workflow YAML parsed; `yarn lint` clean (test-runtime/ is outside the lint scope by design, like test-types/).
- Full local matrix run: 18 then 19, correct per-version reporting and non-zero exit.
- Native run unchanged: 127/127.