### PR TITLE
test: wrap instance-method state updates in act()

### DIFF
--- a/src/lib/Form/Form.test.js
+++ b/src/lib/Form/Form.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 import Form from './Form';
 import Field from '../Field';
@@ -89,7 +89,9 @@ describe('resetOnSubmit prop', () => {
 			/>,
 		);
 
-		ref.current.touch('type');
+		act(() => {
+			ref.current.touch('type');
+		});
 		expect(ref.current.state.touchedFields).toEqual(['type']);
 
 		fireEvent.submit(container.querySelector('form'));
@@ -114,7 +116,9 @@ describe('resetOnSubmit prop', () => {
 			/>,
 		);
 
-		ref.current.touch('type');
+		act(() => {
+			ref.current.touch('type');
+		});
 		fireEvent.submit(container.querySelector('form'));
 
 		// onSubmit still runs, but the visual state survives the submit (so a
@@ -132,12 +136,16 @@ describe('Form.reset()', () => {
 		render(<Form onSubmit={() => {}} ref={ref} schema={{}} />);
 		const instance = ref.current;
 
-		instance.registerFieldError('key', 'type', 'jfv1_type_err');
-		instance.touch('type');
+		act(() => {
+			instance.registerFieldError('key', 'type', 'jfv1_type_err');
+			instance.touch('type');
+		});
 		const versionBeforeReset = instance.state.fieldErrorsVersion;
 		expect(versionBeforeReset).toBeGreaterThan(0);
 
-		instance.reset();
+		act(() => {
+			instance.reset();
+		});
 
 		// The touched/submitted state is wiped, but the version counter is
 		// preserved: the registry (instance Map) was not emptied by reset().
@@ -160,7 +168,9 @@ describe('context reset()', () => {
 			/>,
 		);
 
-		ref.current.touch('type');
+		act(() => {
+			ref.current.touch('type');
+		});
 		// Failed submit (invalid data): isSubmitted stays true, nothing resets.
 		fireEvent.submit(container.querySelector('form'));
 		expect(ref.current.state.touchedFields).toEqual(['type']);
@@ -168,7 +178,9 @@ describe('context reset()', () => {
 
 		const context = ref.current.getContext();
 		expect(typeof context.reset).toBe('function');
-		context.reset();
+		act(() => {
+			context.reset();
+		});
 
 		expect(ref.current.state.touchedFields).toEqual([]);
 		expect(ref.current.state.isSubmitted).toBe(false);
@@ -695,11 +707,17 @@ describe('Form.touch(fieldName)', () => {
 		);
 
 		expect(ref.current.state.touchedFields).toEqual([]);
-		ref.current.touch('type');
+		act(() => {
+			ref.current.touch('type');
+		});
 		expect(ref.current.state.touchedFields).toEqual(['type']);
-		ref.current.touch('name');
+		act(() => {
+			ref.current.touch('name');
+		});
 		expect(ref.current.state.touchedFields).toEqual(['type', 'name']);
-		ref.current.touch('description');
+		act(() => {
+			ref.current.touch('description');
+		});
 		expect(ref.current.state.touchedFields).toEqual(['type', 'name', 'description']);
 	});
 });
@@ -752,9 +770,13 @@ describe('revalidation on update', () => {
 		const validateSpy = vi.spyOn(ref.current, 'validate');
 
 		// touch: internal setState, no prop changed → no validate() dispatch.
-		ref.current.touch('type');
+		act(() => {
+			ref.current.touch('type');
+		});
 		// FieldError registry bump: same story.
-		ref.current.registerFieldError('key1', 'type', 'error-id-1');
+		act(() => {
+			ref.current.registerFieldError('key1', 'type', 'error-id-1');
+		});
 		// Submit on a never-touched-then-touched valid form: isSubmitted
 		// setState plus the default resetOnSubmit reset() — still no prop
 		// change. `valid` was computed at mount, so onSubmit must fire.

--- a/src/lib/a11y.test.js
+++ b/src/lib/a11y.test.js
@@ -7,7 +7,7 @@
  * <Field> points at it, instead of hardcoding `jfv1` everywhere.
  */
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 
 import Form from './Form';
 import Field from './Field';
@@ -182,7 +182,9 @@ it('should reset the unmounting flag on remount (React 18 StrictMode)', () => {
 	instance.componentWillUnmount();
 	instance.componentDidMount();
 
-	instance.unregisterFieldError(key);
+	act(() => {
+		instance.unregisterFieldError(key);
+	});
 	expect(instance.fieldErrorRegistry.size).toBe(0);
 
 	unmount();

--- a/src/lib/a11y.test.js
+++ b/src/lib/a11y.test.js
@@ -180,7 +180,12 @@ it('should reset the unmounting flag on remount (React 18 StrictMode)', () => {
 	// componentWillUnmount followed by componentDidMount. Unregistering
 	// must work again after the remount.
 	instance.componentWillUnmount();
-	instance.componentDidMount();
+	// componentDidMount dispatches the initial validation: only the memoized
+	// data-reference short-circuit keeps it setState-free here — act() makes
+	// the test robust to that internal detail.
+	act(() => {
+		instance.componentDidMount();
+	});
 
 	act(() => {
 		instance.unregisterFieldError(key);


### PR DESCRIPTION
## Root cause

The runtime React matrix (#82) revealed **4 identical failures** in `Form.test.js` under React 18.3.1 and 19.2.8 (123/127 at the time, same 4 on both), with a single root cause: tests call instance methods that trigger `setState` — through a ref (`touch()`, `reset()`, `registerFieldError()`) or the form context (`getContext().reset()`) — **outside `act()`**, then assert `state` synchronously. React 16 legacy mode flushes those `setState` calls synchronously, so the assertions happen to pass. React 18/19 automatic batching (`createRoot`) defers them: the assertions read stale state.

## Fix (test-only)

Wrap every such instance-method call in `act(() => { ... })`, imported from `@testing-library/react` (re-exported by RTL 12 on the native tree and RTL 16 on the matrix fixtures — resolves on all three React versions). **No assertion changed** — only the calls are wrapped.

### The 4 failing tests, fixed
1. `Form.touch(fieldName)` — 3 `ref.current.touch(...)` calls with immediate `touchedFields` assertions
2. `Form.reset()` (fieldErrorsVersion monotonic) — `instance.registerFieldError`/`instance.touch`, then `instance.reset()`
3. `context reset()` — `ref.current.touch(...)` and `context.reset()`
4. `resetOnSubmit` default — `ref.current.touch(...)` before submit

### Preventive wraps (same defect, not yet failing under 18/19)
- `Form.test.js` — `touch()` in the `resetOnSubmit={false}` test (a later act-wrapped `fireEvent.submit` currently flushes it by luck)
- `Form.test.js` — `touch()` and `registerFieldError()` in the revalidation-guard test (assertions are on counters/spies, but the setState still runs un-acted)
- `a11y.test.js` — `unregisterFieldError()` in the StrictMode remount test. The neighbouring unmount no-op test is deliberately **left unwrapped**: it asserts `setState` is *not* called.

`handleFieldChange` and `scrollToFirstError` calls stay untouched — they don't `setState`.

## Proof — full suite green on all 3 React versions

| React | RTL | Result |
|---|---|---|
| 16 (native tree) | 12 | **159/159** (×2 runs) |
| 18.3.1 (matrix fixture) | 16 | **159/159** |
| 19.2.8 (matrix fixture) | 16 | **159/159** |

React 18/19 runs used the #82 `test-runtime/` tooling locally (copied in, **not committed** — it stays in #82's scope). This PR removes the entire known-failure baseline of #82: once both land, the non-blocking matrix jobs can eventually be made blocking.

Also validated: `eslint` clean, `tsc` clean.