### PR TITLE
fix(FieldError): drop defaultProps from the public function wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ and dependency-only bumps are omitted.
 
 ### Fixed
 
+- `<FieldError>` no longer attaches `defaultProps` to its public
+  function wrapper — that pattern is deprecated in React 18.3 (runtime
+  warning "Support for defaultProps will be removed from function
+  components") and silently ignored by React 19. The defaults were
+  already applied by the internal class component, so behavior is
+  unchanged on every supported React version; the warning is simply
+  gone. Class components (`<Form>`, and `<Field>`'s implementation)
+  keep their `defaultProps`, which remain fully supported.
 - The `<Form>` snapshot test no longer serializes the internal AJV
   instance, whose cache state differed between Jest run modes (flaky in
   single-suite runs). Contributor-facing only; no runtime change.

--- a/src/lib/FieldError/FieldError.js
+++ b/src/lib/FieldError/FieldError.js
@@ -239,13 +239,11 @@ FieldError.propTypes = {
 	name: PropTypes.string.isRequired,
 };
 
-FieldError.defaultProps = {
-	children: null,
-	component: 'div',
-	errorMessages: null,
-	className: '',
-	id: null,
-};
+// No `FieldError.defaultProps` here on purpose: defaultProps on FUNCTION
+// components are deprecated in React 18.3 (runtime warning) and silently
+// ignored in React 19. The defaults live on the `FieldErrorInner` CLASS
+// above (still fully supported, like `Form.defaultProps`), which is where
+// the props are actually consumed.
 
 // Polymorphic re-typing: the implementation is non-generic internally (uses
 // `FieldErrorBaseProps`); the cast on the default export restores the


### PR DESCRIPTION
## Why

The runtime React matrix (#82) surfaced this warning on the React 18.3 leg:

```
Warning: FieldError: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
```

Since #65, the public `FieldError` export is a thin **function** wrapper (`withFormContext` + `FieldErrorInner` class), and `defaultProps` were attached to that wrapper. React 18.3 warns about it; **React 19 ignores it silently** — the current behavior is only saved by the fact that the same defaults are duplicated on the inner class.

## What

- Removed `FieldError.defaultProps` (the function wrapper's copy) and left a comment explaining why it must not come back.
- The defaults keep being applied exactly as before, by `FieldErrorInner.defaultProps` (a **class**, fully supported) plus the `component = 'div'` destructuring fallback in its render — that is where the props are actually consumed.
- **Not touched, on purpose:** class `defaultProps` on `Form` and on `Field`'s class implementation (supported everywhere; the revalidation guard of #80 relies on `Form.defaultProps`, as documented in Form.js). `Field`'s `forwardRef` wrapper carries no `defaultProps` — nothing to do there.
- CHANGELOG entry under Unreleased / Fixed.

## Proof

| Run | Tests | `defaultProps` warning |
|---|---|---|
| React 16 (`yarn test:runtime`, x2) | 159/159 both runs | n/a (no warning on 16) |
| React 18.3 fixture — before fix | 159/159 | **2 occurrences** |
| React 18.3 fixture — after fix | 159/159 | **0** |
| React 19 fixture — after fix | 159/159 | 0 |

Lint and type-check pass. No behavior change: every removed default is still applied by the inner class and covered by the existing FieldError suite (default `div` rendering via snapshot, deterministic default id, auto-generated message when no children, form-level errorMessages fallback).