### PR TITLE
feat(validation): expose the current field value on errors (error.data)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and dependency-only bumps are omitted.
 
 ## [Unreleased]
 
+### Added
+
+- Validation errors now carry the current value of the offending field:
+  the default AJV instance is created with `verbose: true`, so every
+  error passed to `errorMessages` callbacks (and exposed through the
+  form context) has `data` — the field's current value for value-level
+  keywords (`minLength`, `format`, `enum`, `const`, `$data`
+  references, …), or the parent object for `required` errors — plus
+  `schema` (the failing keyword's value) and `parentSchema` (the
+  enclosing subschema). Example:
+  ``minLength: (e) => `"${e.data}" is too short (min ${e.params.limit})` ``.
+  If you pass a custom instance through the `ajv` prop, enable
+  `verbose: true` yourself to get the same behavior. Closes #6.
+
 ### Changed
 
 - `dot-prop-immutable` (unmaintained since 2020) is no longer a

--- a/README.md
+++ b/README.md
@@ -148,6 +148,43 @@ class DemoForm extends PureComponent {
 
 🎵 _That's all folks !_ 
 
+## Custom error messages
+
+Pass an `errorMessages` map (keyword → function) to `<Form>` — or to a
+single `<FieldError>` — to replace AJV's raw messages. Each function
+receives the AJV error, which carries the current value of the offending
+field as `error.data`, so messages can quote what the user actually typed:
+
+```jsx
+<Form
+	data={formData}
+	errorMessages={{
+		minLength: (e) => `"${e.data}" is too short (min ${e.params.limit} characters)`,
+		format: (e) => `"${e.data}" is not a valid ${e.params.format}`,
+		required: () => 'This field is required',
+	}}
+	onChange={handleChange}
+	onSubmit={handleSubmit}
+	schema={demoSchema}
+>
+```
+
+What `error.data` contains, per error type:
+
+- value-level keywords (`minLength`, `format`, `enum`, `const`, `pattern`,
+  `minimum`, … including `$data` references): the current value of the field;
+- `required`: the **parent object** missing the property (AJV reports
+  `required` on the parent — the missing value itself does not exist).
+  Use `e.params.missingProperty` for the field name.
+
+Errors also expose `error.schema` (the failing keyword's value, e.g. `5`
+for `minLength: 5`) and `error.parentSchema` (the enclosing subschema).
+
+> **Note** — these properties come from AJV's `verbose` option, enabled on
+> the default instance. If you pass your own instance through the `ajv`
+> prop of `<Form>`, set `verbose: true` yourself to benefit from
+> `error.data`.
+
 ## Accessibility
 
 `<Field>` and `<FieldError>` wire the essential ARIA attributes for you — no

--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ field as `error.data`, so messages can quote what the user actually typed:
 	onSubmit={handleSubmit}
 	schema={demoSchema}
 >
+	<Field name="email" value={formData.email} />
+	<FieldError name="email" />
+	<button type="submit">Submit</button>
+</Form>
 ```
 
 What `error.data` contains, per error type:
@@ -179,6 +183,13 @@ What `error.data` contains, per error type:
 
 Errors also expose `error.schema` (the failing keyword's value, e.g. `5`
 for `minLength: 5`) and `error.parentSchema` (the enclosing subschema).
+
+> **Serialization & logging** — with `verbose`, a `required` error carries
+> the *entire parent object* in `error.data`. A `JSON.stringify(errors)`
+> shipped to monitoring or logs can therefore exfiltrate sensitive sibling
+> fields (a password living next to the missing property, for instance),
+> and cyclic data would make `stringify` throw. Log a projection of chosen
+> fields (`field`, `keyword`, `message`) rather than raw error objects.
 
 > **Note** — these properties come from AJV's `verbose` option, enabled on
 > the default instance. If you pass your own instance through the `ajv`

--- a/src/lib/FieldError/getErrorMessage.test.js
+++ b/src/lib/FieldError/getErrorMessage.test.js
@@ -41,6 +41,10 @@ it('should pass the current field value (error.data) to the errorMessages callba
 	validate({ name: 'abc' });
 	const [error] = formatErrors(validate.errors);
 
+	// The arrow is hoisted into a const on purpose: inlined as an object
+	// property inside the getErrorMessage() call, its template literal
+	// crashes babel-eslint 10.0.3 (`template-curly-spacing` token-range
+	// bug, fixed in babel-eslint 10.1.0). Do not re-inline it.
 	const minLength = (e) => `"${e.data}" is too short (min ${e.params.limit})`;
 	const message = getErrorMessage(error, { minLength });
 

--- a/src/lib/FieldError/getErrorMessage.test.js
+++ b/src/lib/FieldError/getErrorMessage.test.js
@@ -1,4 +1,5 @@
 import getErrorMessage from './getErrorMessage';
+import { createAjv, formatErrors } from '../Form/helpers';
 
 it('should return a message based on error keyword', () => {
 	expect(getErrorMessage(
@@ -24,6 +25,26 @@ it('should call the default message function if no handler exists for this error
 it('should return the error.message if no handler exists for this error and no default message function is defined', () => {
 	const error = { keyword: 'err1', message: 'err1:message:default' };
 	expect(getErrorMessage(error)).toBe('err1:message:default');
+});
+
+// Issue #6: end-to-end — an error produced by the default AJV instance
+// (verbose: true) reaches the errorMessages callback carrying `data`
+// (the current value of the offending field), ready to interpolate.
+it('should pass the current field value (error.data) to the errorMessages callback', () => {
+	const ajv = createAjv();
+	const validate = ajv.compile({
+		type: 'object',
+		properties: {
+			name: { type: 'string', minLength: 5 },
+		},
+	});
+	validate({ name: 'abc' });
+	const [error] = formatErrors(validate.errors);
+
+	const minLength = (e) => `"${e.data}" is too short (min ${e.params.limit})`;
+	const message = getErrorMessage(error, { minLength });
+
+	expect(message).toBe('"abc" is too short (min 5)');
 });
 
 // Regression: the debug flag branch used to reference `process.env` unguarded,

--- a/src/lib/Form/helpers.js
+++ b/src/lib/Form/helpers.js
@@ -16,6 +16,16 @@ import setIn from './setIn';
  * know `dataPath`; AJV 8 errors carry `instancePath` instead, and
  * {@link formatErrors} accepts both shapes.
  *
+ * Because {@link createAjv} enables AJV's `verbose` option (issue #6),
+ * errors also carry `data` (the current value of the offending field —
+ * for `required` errors it is the parent object missing the property),
+ * `schema` (the failing keyword's value) and `parentSchema` (the
+ * enclosing subschema). Those three properties are already declared as
+ * optional on AJV 6's `ErrorObject` (`data?: any`, `schema?: any`,
+ * `parentSchema?: object`), so they are inherited here — no re-declaration
+ * needed. They stay `undefined` when a custom `ajv` prop is passed to
+ * `<Form>` without `verbose: true`.
+ *
  * @typedef {ErrorObject & { instancePath?: string, field: string }} FormattedError
  */
 
@@ -75,19 +85,29 @@ import setIn from './setIn';
 /**
  * Returns a default AJV instance configured for use with the form.
  *
+ * `verbose: true` (issue #6) makes AJV attach `data`, `schema` and
+ * `parentSchema` to every error, so `errorMessages` callbacks can
+ * interpolate the current value of the offending field (`error.data`).
+ *
  * @returns {Ajv.Ajv}
  */
 export const createAjv = () => new Ajv(
 	// Cast: the `v5` option no longer exists in AJV 6+ typings (it was a
 	// flag from AJV 3/4 that enabled draft-05 features, which became the
 	// default later). The runtime silently ignores unknown options. Kept
-	// here verbatim from the historical code so the lib stays byte-for-byte
-	// equivalent (notably for the Form snapshot test that captures AJV's
-	// internal `_opts` / `_metaOpts` state).
+	// here verbatim from the historical code.
 	/** @type {Ajv.Options} */ ({
 		allErrors: true,
 		v5: true,
 		$data: true,
+		// Issue #6: expose the offending value to `errorMessages` callbacks.
+		// For value-level keywords (minLength, format, enum, const — including
+		// `$data` references) `error.data` is the current field value; for
+		// `required` it is the *parent object* missing the property (AJV
+		// reports `required` on the parent, the missing value itself does
+		// not exist). `error.schema` is the failing keyword's value and
+		// `error.parentSchema` the enclosing subschema.
+		verbose: true,
 	}),
 );
 

--- a/src/lib/Form/helpers.test.js
+++ b/src/lib/Form/helpers.test.js
@@ -9,6 +9,73 @@ describe('.createAjv()', () => {
 		const ajv = helpers.createAjv();
 		expect(ajv).toBeInstanceOf(Ajv);
 	});
+
+	// Issue #6: `verbose: true` makes AJV attach the offending value to each
+	// error as `error.data`, so `errorMessages` callbacks can interpolate it.
+	describe('verbose errors (issue #6)', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				name: { type: 'string', minLength: 5 },
+			},
+			required: ['name', 'age'],
+		};
+
+		it('should attach the current field value as `data` on value-level errors (minLength)', () => {
+			const ajv = helpers.createAjv();
+			const validate = ajv.compile(schema);
+			validate({ name: 'abc' });
+
+			const minLengthError = validate.errors.find((e) => e.keyword === 'minLength');
+			expect(minLengthError.data).toBe('abc');
+			// `schema` is the failing keyword's value, `parentSchema` the
+			// enclosing subschema.
+			expect(minLengthError.schema).toBe(5);
+			expect(minLengthError.parentSchema).toEqual({ type: 'string', minLength: 5 });
+		});
+
+		it('should attach the parent object as `data` on required errors (the missing value itself does not exist)', () => {
+			const ajv = helpers.createAjv();
+			const validate = ajv.compile(schema);
+			const formData = { name: 'valid name' };
+			validate(formData);
+
+			const requiredError = validate.errors.find((e) => e.keyword === 'required');
+			expect(requiredError.params.missingProperty).toBe('age');
+			// AJV reports `required` on the parent object: `data` is that
+			// object, not the (nonexistent) missing value.
+			expect(requiredError.data).toBe(formData);
+		});
+
+		it('should attach the current field value as `data` on $data-reference errors', () => {
+			const ajv = helpers.createAjv();
+			const validate = ajv.compile({
+				type: 'object',
+				properties: {
+					email: { type: 'string' },
+					emailConfirm: { const: { $data: '1/email' } },
+				},
+			});
+			validate({ email: 'a@b.fr', emailConfirm: 'oops' });
+
+			const constError = validate.errors.find((e) => e.keyword === 'const');
+			// `data` is the value of the field under validation; `schema`
+			// stays the raw (unresolved) $data reference.
+			expect(constError.data).toBe('oops');
+			expect(constError.schema).toEqual({ $data: '1/email' });
+		});
+
+		it('should keep `data` available after formatErrors()', () => {
+			const ajv = helpers.createAjv();
+			const validate = ajv.compile(schema);
+			validate({ name: 'abc' });
+
+			const errors = helpers.formatErrors(validate.errors);
+			const minLengthError = errors.find((e) => e.keyword === 'minLength');
+			expect(minLengthError.field).toBe('name');
+			expect(minLengthError.data).toBe('abc');
+		});
+	});
 });
 
 describe('.empty(value)', () => {

--- a/test-types/positive.tsx
+++ b/test-types/positive.tsx
@@ -307,6 +307,27 @@ type _ErrMapValuesAreFns = Expect<Equal<
 	ErrorMessageFn
 >>;
 
+// Type-level check (issue #6): the verbose-mode properties inherited from
+// AJV 6's `ErrorObject` (`data?: any`, `parentSchema?: object`) are visible
+// on the error received by an errorMessages callback, so interpolating the
+// current field value compiles without casting. `data` is locked to `any`
+// (AJV's declared type) — if it ever disappeared from the error type,
+// the indexed access below would fail to compile.
+type _ErrCallbackDataExposed = Expect<Equal<
+	Parameters<ErrorMessageFn>[0]['data'],
+	any
+>>;
+type _ErrCallbackParentSchemaExposed = Expect<Equal<
+	Parameters<ErrorMessageFn>[0]['parentSchema'],
+	object | undefined
+>>;
+
+// Usage: a callback quoting the offending value (issue #6) compiles.
+const dataAwareMessages: ErrorMessagesMap = {
+	minLength: (err) => `"${err.data}" is too short`,
+};
+void dataAwareMessages;
+
 // ---------------------------------------------------------------------------
 // 9. Legacy render-prop still works
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The need

Issue #6 — open since 2020, the oldest in the repo. `errorMessages` callbacks receive the formatted AJV error but not the current value of the field, so a message can't quote what the user actually typed.

## The solution

Enable AJV's `verbose: true` on the default instance created by `createAjv()`. AJV then attaches to every error:

- `data` — the offending value,
- `schema` — the failing keyword's value (e.g. `5` for `minLength: 5`),
- `parentSchema` — the enclosing subschema.

These three properties are already declared optional on AJV 6's `ErrorObject` typings, so `FormattedError` inherits them with **no type change** — TypeScript consumers see them immediately.

```jsx
<Form
  errorMessages={{
    minLength: (e) => `"${e.data}" is too short (min ${e.params.limit} characters)`,
  }}
  ...
/>
```

## What `error.data` contains, per error type (verified against the bundled AJV 6.14)

| Error type | `error.data` |
| --- | --- |
| Value-level keywords (`minLength`, `format`, `enum`, `const`, `pattern`, `minimum`, …) | The current value of the field (e.g. `"abc"`) |
| `$data` references (e.g. `const: { $data: '1/email' }`) | The current value of the field under validation (`error.schema` stays the raw, unresolved `$data` reference) |
| `required` | The **parent object** missing the property — the missing value itself does not exist; use `e.params.missingProperty` for the field name |

## Custom AJV instances

If you pass your own instance through the `ajv` prop of `<Form>`, enable `verbose: true` yourself to benefit from `error.data` — documented in the new README section (*Custom error messages*).

## Tests

5 new tests (159 → 164), all proven to bite: removing `verbose: true` makes exactly these 5 fail (`data` is `undefined`) while the other 159 stay green.

- `helpers.test.js`: real validations through `createAjv()` — `minLength` → `data` is the offending string, `required` → `data` is the parent object, `$data` const → `data` is the field value, and `data` survives `formatErrors()`.
- `getErrorMessage.test.js`: end-to-end — an error from the default instance reaches an `errorMessages` callback and interpolates to the literal `'"abc" is too short (min 5)'`.

Full suite green on React 16 (native), 18 and 19 (runtime matrix), types matrix green on @types/react 16–19, lint and type-check clean. The Form snapshot is DOM-only (#67), so larger error objects can't leak into it.

Closes #6