### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and dependency-only bumps are omitted.
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-08-25
+
 ### Added
 
 - Validation errors now carry the current value of the offending field:
@@ -223,7 +225,8 @@ Initial public release.
   copy on every field change.
 - `react-select` wrapper.
 
-[Unreleased]: https://github.com/53js/react-jsonschema-form-validation/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/53js/react-jsonschema-form-validation/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/53js/react-jsonschema-form-validation/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/53js/react-jsonschema-form-validation/compare/71300db...v0.6.0
 [0.5.6]: https://github.com/53js/react-jsonschema-form-validation/compare/8534580...71300db
 [0.5.5]: https://github.com/53js/react-jsonschema-form-validation/compare/53a58a8...8534580

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "react-jsonschema-form-validation",
 	"description": "Simple form validation using JSON Schema and AJV",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"author": "53JS",
 	"license": "MIT",
 	"scripts": {


### PR DESCRIPTION
Version bump and CHANGELOG finalization for **v0.7.0**.

- `package.json` version 0.6.0 → 0.7.0
- CHANGELOG: `[Unreleased]` → `[0.7.0] — 2026-08-25` (+ compare links)

Once merged, the `v0.7.0` tag on the merge commit triggers `release.yml` (full verification then `npm publish --provenance`). Local build was validated in a real project by Alexis. Release notes: see the 0.7.0 CHANGELOG section (peer range narrowed to react >=16.8, ESM-only dist, scroll options semantics, `resetOnSubmit`, full a11y wiring, `error.data`, …).