### PR TITLE
feat(v1): Standard Schema core + AJV provider subpath (providers/ajv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ and dependency-only bumps are omitted.
   `code` maps `minimum`/`exclusiveMinimum` → `min` and `maximum`/`exclusiveMaximum`
   → `max`, every other AJV keyword passes through; `raw` is the verbose AJV
   error, so `raw.data` is the current field value). The root entry exports the
-  `FormError` / `ErrorCode` / `StandardSchema` types, `isStandardSchema()` and
-  `runSchema()`. Validation is synchronous only: a schema returning a Promise
-  throws. `<Form>` is not wired to it yet — that lands with `useForm`.
+  `FormError` / `ErrorCode` / `StandardSchema` types (types only). Validation
+  is synchronous only: a schema returning a Promise (an `$async` JSON Schema,
+  an async refinement) throws. `<Form>` is not wired to it yet — that lands
+  with `useForm`.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and dependency-only bumps are omitted.
 
 ## [Unreleased]
 
+### Added
+
+- **Standard Schema groundwork (RFC 0001).** New subpath
+  `react-jsonschema-form-validation/providers/ajv` exporting `ajvSchema(jsonSchema, { ajv })`,
+  which wraps a JSON Schema into a [Standard Schema v1](https://standardschema.dev)
+  object (plus `createAjv()` to build a custom AJV 8 instance). Its errors
+  use the normalized `FormError` shape (`{ field, code, message, params, raw }`;
+  `code` maps `minimum`/`exclusiveMinimum` → `min` and `maximum`/`exclusiveMaximum`
+  → `max`, every other AJV keyword passes through; `raw` is the verbose AJV
+  error, so `raw.data` is the current field value). The root entry exports the
+  `FormError` / `ErrorCode` / `StandardSchema` types, `isStandardSchema()` and
+  `runSchema()`. Validation is synchronous only: a schema returning a Promise
+  throws. `<Form>` is not wired to it yet — that lands with `useForm`.
+
 ### Breaking
 
 - **React 18 is now the minimum supported version** (`peerDependencies:

--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
 		"dist": "yarn clean && yarn dist:css && yarn dist:js && yarn dist:types && yarn minify:css",
 		"dist:css": "sass --style=expanded --no-source-map src/lib/styles/main.scss dist/$npm_package_name.css",
 		"dist:js": "vite build --config vite.lib.config.js",
-		"dist:types": "yarn dist:types:emit && yarn dist:types:bundle && yarn dist:types:cleanup",
-		"dist:types:emit": "tsc -p tsconfig.build.json",
-		"dist:types:bundle": "dts-bundle-generator -o dist/index.d.ts --no-banner --no-check .types-temp/index.d.ts",
-		"dist:types:cleanup": "rm -rf .types-temp",
+		"dist:types": "tsc -p tsconfig.build.json",
 		"minify:css": "cleancss --level 1 --source-map --source-map-inline-sources --output dist/$npm_package_name.min.css dist/$npm_package_name.css",
 		"test": "yarn test:runtime && yarn test:types",
 		"test:runtime": "vitest run",
@@ -38,9 +35,20 @@
 			"types": "./dist/index.d.ts",
 			"default": "./dist/index.js"
 		},
+		"./providers/ajv": {
+			"types": "./dist/providers/ajv/index.d.ts",
+			"default": "./dist/providers/ajv/index.js"
+		},
 		"./package.json": "./package.json",
 		"./dist/react-jsonschema-form-validation.css": "./dist/react-jsonschema-form-validation.css",
 		"./dist/react-jsonschema-form-validation.min.css": "./dist/react-jsonschema-form-validation.min.css"
+	},
+	"typesVersions": {
+		"*": {
+			"providers/ajv": [
+				"dist/providers/ajv/index.d.ts"
+			]
+		}
 	},
 	"sideEffects": [
 		"*.css"
@@ -76,7 +84,6 @@
 		"babel-eslint": "10.0.3",
 		"bootstrap": "^4.4.1",
 		"clean-css-cli": "^4.3.0",
-		"dts-bundle-generator": "^9.5.1",
 		"eslint": "^6.1.0",
 		"eslint-config-53js": "^1.2.0",
 		"eslint-config-airbnb": "^18.0.1",
@@ -95,13 +102,13 @@
 		"sass": "^1.101.7",
 		"typescript": "^6.0.3",
 		"vite": "^6.4.3",
-		"vitest": "^3.2.6"
+		"vitest": "^3.2.6",
+		"zod": "^4"
 	},
 	"peerDependencies": {
 		"react": ">=18"
 	},
 	"resolutions": {
-		"dts-bundle-generator/typescript": "^6.0.3",
 		"**/vite": "^6.4.3"
 	},
 	"keywords": [

--- a/src/lib/Form/helpers.js
+++ b/src/lib/Form/helpers.js
@@ -186,19 +186,38 @@ export const formatData = (data) => {
 const unescapePointerSegment = (segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~');
 
 /**
- * Converts a JSON Pointer (RFC 6901, the shape of AJV 8's
- * `error.instancePath`, e.g. `'/items/0/label'`) into the library's
- * dot-separated field path (`'items.0.label'`). The root pointer `''`
- * maps to the empty field path `''`.
+ * Splits a JSON Pointer (RFC 6901, the shape of AJV 8's `error.instancePath`,
+ * e.g. `'/items/0/label'`) into its decoded reference tokens
+ * (`['items', '0', 'label']`). The root pointer `''` yields no segment.
+ *
+ * @param {string} pointer
+ * @returns {string[]}
+ */
+export const pointerToSegments = (pointer) => pointer
+	.split('/')
+	.slice(1)
+	.map(unescapePointerSegment);
+
+/**
+ * Converts a JSON Pointer into the library's dot-separated field path
+ * (`'items.0.label'`). The root pointer `''` maps to the empty field path `''`.
  *
  * @param {string} pointer
  * @returns {string}
  */
-export const pointerToFieldPath = (pointer) => pointer
-	.split('/')
-	.slice(1)
-	.map(unescapePointerSegment)
-	.join('.');
+export const pointerToFieldPath = (pointer) => pointerToSegments(pointer).join('.');
+
+/**
+ * Converts a legacy AJV 6 `error.dataPath` (dot notation with bracketed
+ * array indexes, e.g. `'.items[0].label'`) into the library's dot-separated
+ * field path (`'items.0.label'`).
+ *
+ * @param {string} dataPath
+ * @returns {string}
+ */
+export const dataPathToFieldPath = (dataPath) => dataPath
+	.replace(/^\./, '')
+	.replace(/\[([0-9]+)\]/g, '.$1');
 
 /**
  * Enriches each AJV error with a normalized `field` path. The transformation
@@ -227,9 +246,7 @@ export const formatErrors = (errors) => (errors || []).map((error) => {
 		// AJV 6 shape: dot notation with bracketed array indexes. A
 		// degenerate error carrying neither `instancePath` nor `dataPath`
 		// is treated as pointing at the root instead of crashing.
-		formatted.field = (formatted.dataPath ?? '')
-			.replace(/^\./, '')
-			.replace(/\[([0-9]+)\]/g, '.$1');
+		formatted.field = dataPathToFieldPath(formatted.dataPath ?? '');
 	}
 
 	if (formatted.keyword === 'required' && 'missingProperty' in formatted.params) {

--- a/src/lib/core/errors.js
+++ b/src/lib/core/errors.js
@@ -1,0 +1,123 @@
+/**
+ * Normalized validation errors — the shape the whole library speaks,
+ * whatever the validation provider (RFC 0001, "Validator spec").
+ *
+ * @import { StandardSchema, StandardSchemaIssue, StandardSchemaResult } from './standard-schema'
+ */
+
+/**
+ * Normalized error-code core. Providers map their own codes into it;
+ * anything unmapped passes through under the provider's own code (the
+ * `(string & {})` member keeps autocomplete on the known codes while
+ * accepting any string). Documented pass-through boundary for AJV:
+ * `oneOf`/`anyOf`, `multipleOf`, `uniqueItems`, `minItems`/`maxItems`,
+ * `const`, `additionalProperties`.
+ *
+ * @typedef {(
+ *   'required' | 'type' | 'min' | 'max' | 'minLength' | 'maxLength'
+ *   | 'pattern' | 'format' | 'enum'
+ *   | (string & {})
+ * )} ErrorCode
+ */
+
+/**
+ * - `field`   — dot-path of the offending field (`'user.email'`,
+ *               `'items.0.label'`); `''` for a root-level error.
+ * - `code`    — normalized code, or the provider's own when unmapped,
+ *               `'unknown'` when the issue carries none.
+ * - `message` — provider default message.
+ * - `params`  — provider parameters (AJV: `{ limit }`, `{ missingProperty }`…),
+ *               `{}` when the provider has none.
+ * - `raw`     — the original provider issue/error, untouched (AJV in verbose
+ *               mode: `raw.data` is the current value of the field — issue #6).
+ *
+ * @typedef {{
+ *   field: string,
+ *   code: ErrorCode,
+ *   message: string,
+ *   params: Record<string, unknown>,
+ *   raw: unknown,
+ * }} FormError
+ */
+
+/**
+ * Issue shape emitted by the library's own providers: the Standard Schema
+ * issue plus the optional members `normalizeIssues` reads. Third-party
+ * schemas (Zod…) emit their own issue objects, which usually carry a
+ * `code` too — read opportunistically, never required.
+ *
+ * @typedef {StandardSchemaIssue & {
+ *   code?: unknown,
+ *   params?: unknown,
+ *   raw?: unknown,
+ * }} ProviderIssue
+ */
+
+/**
+ * @param {PropertyKey | { key: PropertyKey }} segment
+ * @returns {string}
+ */
+const segmentToString = (segment) => {
+	const key = typeof segment === 'object' && segment !== null ? segment.key : segment;
+	return String(key);
+};
+
+/**
+ * Converts a Standard Schema issue path to the library's dot-path.
+ *
+ * @param {StandardSchemaIssue['path']} path
+ * @returns {string}
+ */
+export const pathToField = (path) => (path || []).map(segmentToString).join('.');
+
+/**
+ * @param {ReadonlyArray<StandardSchemaIssue>} issues
+ * @returns {FormError[]}
+ */
+export const normalizeIssues = (issues) => issues.map((issue) => {
+	const { code, params, raw } = /** @type {ProviderIssue} */ (issue);
+	return {
+		field: pathToField(issue.path),
+		code: typeof code === 'string' ? code : 'unknown',
+		message: issue.message,
+		params: params !== null && typeof params === 'object'
+			? /** @type {Record<string, unknown>} */ (params)
+			: {},
+		raw: raw !== undefined ? raw : issue,
+	};
+});
+
+/**
+ * Sync-only guard (RFC 0001): Standard Schema allows `validate()` to return
+ * a Promise (async refinements). The library validates on every change and
+ * has no stale-result handling, so async schemas are rejected loudly.
+ *
+ * @template Output
+ * @param {StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>} result
+ * @returns {StandardSchemaResult<Output>}
+ */
+export const assertSyncResult = (result) => {
+	const thenable = /** @type {{ then?: unknown }} */ (result);
+	if (result instanceof Promise || typeof thenable.then === 'function') {
+		throw new Error(
+			'react-jsonschema-form-validation: the schema returned a Promise from validate(). '
+			+ 'Async validation is not supported (sync-only in v1).',
+		);
+	}
+	return result;
+};
+
+/**
+ * Runs a Standard Schema synchronously and returns the normalized errors.
+ *
+ * @param {StandardSchema} schema
+ * @param {unknown} data
+ * @returns {{ valid: boolean, errors: FormError[] }}
+ */
+export const runSchema = (schema, data) => {
+	const result = assertSyncResult(schema['~standard'].validate(data));
+	if (result.issues && result.issues.length) {
+		return { valid: false, errors: normalizeIssues(result.issues) };
+	}
+	return { valid: true, errors: [] };
+};

--- a/src/lib/core/errors.js
+++ b/src/lib/core/errors.js
@@ -87,22 +87,34 @@ export const normalizeIssues = (issues) => issues.map((issue) => {
 	};
 });
 
+export const SYNC_ONLY_ERROR_MESSAGE = (
+	'react-jsonschema-form-validation: the schema returned a Promise from validate(). '
+	+ 'Async validation is not supported (sync-only in v1).'
+);
+
 /**
  * Sync-only guard (RFC 0001): Standard Schema allows `validate()` to return
  * a Promise (async refinements). The library validates on every change and
  * has no stale-result handling, so async schemas are rejected loudly.
  *
- * @template Output
- * @param {StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>} result
- * @returns {StandardSchemaResult<Output>}
+ * The rejected promise is never left dangling: an AJV `$async` validator
+ * rejects on invalid data, which would surface as an unhandled rejection
+ * on top of the error thrown here.
+ *
+ * Generic on purpose: the AJV provider guards the raw validator return
+ * value (`boolean | Promise`) with it, not only Standard Schema results.
+ *
+ * @template T
+ * @param {T | Promise<T>} result
+ * @returns {T}
  */
 export const assertSyncResult = (result) => {
 	const thenable = /** @type {{ then?: unknown }} */ (result);
 	if (result instanceof Promise || typeof thenable.then === 'function') {
-		throw new Error(
-			'react-jsonschema-form-validation: the schema returned a Promise from validate(). '
-			+ 'Async validation is not supported (sync-only in v1).',
-		);
+		// `Promise.resolve` returns a native promise as-is and adopts any
+		// other thenable, so the rejection handler always lands.
+		Promise.resolve(result).then(undefined, () => {});
+		throw new Error(SYNC_ONLY_ERROR_MESSAGE);
 	}
 	return result;
 };

--- a/src/lib/core/errors.test.js
+++ b/src/lib/core/errors.test.js
@@ -122,7 +122,16 @@ describe('Zod 4 through ~standard (real third-party Standard Schema)', () => {
 		expect(isStandardSchema(schema)).toBe(true);
 		expect(isStandardSchema({})).toBe(false);
 		expect(isStandardSchema(null)).toBe(false);
+		expect(isStandardSchema(42)).toBe(false);
 		expect(isStandardSchema({ '~standard': { validate: 'nope' } })).toBe(false);
+	});
+
+	it('should accept a callable schema carrying ~standard (ArkType-style Type)', () => {
+		const callable = () => {};
+		callable['~standard'] = { version: 1, vendor: 'arktype', validate: () => ({ value: 1 }) };
+		expect(isStandardSchema(callable)).toBe(true);
+		expect(runSchema(callable, 1)).toEqual({ valid: true, errors: [] });
+		expect(isStandardSchema(() => {})).toBe(false);
 	});
 
 	it('should pass Zod codes through unchanged (no zod provider yet) with dot-path fields', () => {
@@ -146,7 +155,10 @@ describe('Zod 4 through ~standard (real third-party Standard Schema)', () => {
 		const minError = errors.find((e) => e.field === 'min');
 		expect(minError.raw).toMatchObject({ code: 'too_small', origin: 'number', minimum: 5 });
 		expect(minError.params).toEqual({});
-		expect(minError.message).toBe('Too small: expected number to be >=5');
+		// Zod's own wording is not ours to lock: the message must be the
+		// provider's, verbatim.
+		expect(minError.message).toBe(minError.raw.message);
+		expect(minError.message).not.toBe('');
 	});
 
 	it('should report valid on conforming data', () => {

--- a/src/lib/core/errors.test.js
+++ b/src/lib/core/errors.test.js
@@ -1,0 +1,157 @@
+import { z } from 'zod';
+
+import {
+	assertSyncResult,
+	normalizeIssues,
+	pathToField,
+	runSchema,
+} from './errors';
+import { isStandardSchema } from './standard-schema';
+
+describe('pathToField(path)', () => {
+	it('should map a missing or empty path to the root field ""', () => {
+		expect(pathToField(undefined)).toBe('');
+		expect(pathToField([])).toBe('');
+	});
+
+	it('should join property keys and array indexes with dots', () => {
+		expect(pathToField(['items', 0, 'label'])).toBe('items.0.label');
+	});
+
+	it('should unwrap { key } segments (the spec escape hatch)', () => {
+		expect(pathToField([{ key: 'user' }, { key: 2 }, 'email'])).toBe('user.2.email');
+	});
+});
+
+describe('normalizeIssues(issues)', () => {
+	it('should map a provider issue to the FormError shape', () => {
+		const raw = { keyword: 'minLength' };
+		const [error] = normalizeIssues([{
+			message: 'too short',
+			path: ['user', 'name'],
+			code: 'minLength',
+			params: { limit: 3 },
+			raw,
+		}]);
+		expect(error).toEqual({
+			field: 'user.name',
+			code: 'minLength',
+			message: 'too short',
+			params: { limit: 3 },
+			raw,
+		});
+		expect(error.raw).toBe(raw);
+	});
+
+	it('should fall back to code "unknown" when the issue carries no string code', () => {
+		expect(normalizeIssues([{ message: 'x' }])[0].code).toBe('unknown');
+		expect(normalizeIssues([{ message: 'x', code: 42 }])[0].code).toBe('unknown');
+	});
+
+	it('should default params to an empty object when absent or not an object', () => {
+		expect(normalizeIssues([{ message: 'x' }])[0].params).toEqual({});
+		expect(normalizeIssues([{ message: 'x', params: null }])[0].params).toEqual({});
+		expect(normalizeIssues([{ message: 'x', params: 'nope' }])[0].params).toEqual({});
+	});
+
+	it('should use the issue itself as raw when the provider gives none', () => {
+		const issue = { message: 'x', path: ['a'] };
+		expect(normalizeIssues([issue])[0].raw).toBe(issue);
+	});
+});
+
+describe('assertSyncResult(result)', () => {
+	it('should return a synchronous result untouched', () => {
+		const result = { value: { a: 1 } };
+		expect(assertSyncResult(result)).toBe(result);
+	});
+
+	it('should throw an explicit error on a Promise (sync-only in v1)', () => {
+		expect(() => assertSyncResult(Promise.resolve({ value: 1 }))).toThrow(
+			'react-jsonschema-form-validation: the schema returned a Promise from validate(). '
+			+ 'Async validation is not supported (sync-only in v1).',
+		);
+	});
+
+	it('should treat any thenable as async', () => {
+		expect(() => assertSyncResult({ then: () => {} })).toThrow(/Async validation is not supported/);
+	});
+});
+
+describe('runSchema(schema, data)', () => {
+	const schemaOf = (validate) => ({ '~standard': { version: 1, vendor: 'test', validate } });
+
+	it('should report valid with no errors on a successful result', () => {
+		expect(runSchema(schemaOf(() => ({ value: 1 })), 1)).toEqual({ valid: true, errors: [] });
+	});
+
+	it('should treat an empty issue list as valid', () => {
+		expect(runSchema(schemaOf(() => ({ issues: [] })), 1)).toEqual({ valid: true, errors: [] });
+	});
+
+	it('should pass the data to validate() and normalize the issues', () => {
+		const validate = vi.fn(() => ({ issues: [{ message: 'bad', path: ['a'], code: 'type' }] }));
+		const result = runSchema(schemaOf(validate), { a: 1 });
+		expect(validate).toHaveBeenCalledWith({ a: 1 });
+		expect(result.valid).toBe(false);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]).toMatchObject({ field: 'a', code: 'type', message: 'bad' });
+	});
+
+	it('should throw on an async schema', () => {
+		expect(() => runSchema(schemaOf(async () => ({ value: 1 })), 1)).toThrow(/sync-only/);
+	});
+});
+
+describe('Zod 4 through ~standard (real third-party Standard Schema)', () => {
+	const schema = z.object({
+		req: z.string(),
+		min: z.number().min(5),
+		max: z.number().max(5),
+		minLen: z.string().min(3),
+		fmt: z.string().email(),
+		enm: z.enum(['a']),
+		nested: z.object({ deep: z.string() }),
+		list: z.array(z.object({ label: z.string().min(2) })),
+	});
+	const data = {
+		min: 1, max: 9, minLen: 'a', fmt: 'nope', enm: 'z', nested: {}, list: [{ label: 'ok' }, { label: 'x' }],
+	};
+
+	it('should be detected by isStandardSchema', () => {
+		expect(isStandardSchema(schema)).toBe(true);
+		expect(isStandardSchema({})).toBe(false);
+		expect(isStandardSchema(null)).toBe(false);
+		expect(isStandardSchema({ '~standard': { validate: 'nope' } })).toBe(false);
+	});
+
+	it('should pass Zod codes through unchanged (no zod provider yet) with dot-path fields', () => {
+		const { valid, errors } = runSchema(schema, data);
+		expect(valid).toBe(false);
+		const codes = Object.fromEntries(errors.map((e) => [e.field, e.code]));
+		expect(codes).toEqual({
+			req: 'invalid_type',
+			min: 'too_small',
+			max: 'too_big',
+			minLen: 'too_small',
+			fmt: 'invalid_format',
+			enm: 'invalid_value',
+			'nested.deep': 'invalid_type',
+			'list.1.label': 'too_small',
+		});
+	});
+
+	it('should keep the Zod issue as raw, with empty params and the Zod message', () => {
+		const { errors } = runSchema(schema, data);
+		const minError = errors.find((e) => e.field === 'min');
+		expect(minError.raw).toMatchObject({ code: 'too_small', origin: 'number', minimum: 5 });
+		expect(minError.params).toEqual({});
+		expect(minError.message).toBe('Too small: expected number to be >=5');
+	});
+
+	it('should report valid on conforming data', () => {
+		expect(runSchema(schema, {
+			req: 'x', min: 5, max: 5, minLen: 'abc', fmt: 'a@b.co', enm: 'a', nested: { deep: 'd' }, list: [],
+		})).toEqual({ valid: true, errors: [] });
+	});
+});

--- a/src/lib/core/standard-schema.js
+++ b/src/lib/core/standard-schema.js
@@ -1,0 +1,61 @@
+/**
+ * Vendored Standard Schema v1 interface (https://standardschema.dev).
+ *
+ * The spec is designed to be copied rather than depended upon: any object
+ * carrying a `~standard` property with this shape is accepted as a
+ * validation schema — Zod (>= 3.24), Valibot, ArkType, Effect Schema
+ * implement it natively; JSON Schema goes through the bundled AJV provider
+ * (`react-jsonschema-form-validation/providers/ajv`). Only the members the
+ * library reads are declared.
+ */
+
+/**
+ * One reported problem. `path` is absent for root-level issues; each
+ * segment is either a property key or an object carrying it (`{ key }`,
+ * the spec's escape hatch for non-serializable keys).
+ *
+ * @typedef {{
+ *   message: string,
+ *   path?: ReadonlyArray<PropertyKey | { key: PropertyKey }>,
+ * }} StandardSchemaIssue
+ */
+
+/**
+ * @template Output
+ * @typedef {(
+ *   { value: Output, issues?: undefined }
+ *   | { issues: ReadonlyArray<StandardSchemaIssue> }
+ * )} StandardSchemaResult
+ */
+
+/**
+ * @template [Input = unknown]
+ * @template [Output = Input]
+ * @typedef {{
+ *   version: 1,
+ *   vendor: string,
+ *   validate: (value: unknown) =>
+ *     StandardSchemaResult<Output> | Promise<StandardSchemaResult<Output>>,
+ *   types?: { input: Input, output: Output },
+ * }} StandardSchemaProps
+ */
+
+/**
+ * @template [Input = unknown]
+ * @template [Output = Input]
+ * @typedef {{ '~standard': StandardSchemaProps<Input, Output> }} StandardSchema
+ */
+
+/**
+ * Duck-typed guard: does `value` implement Standard Schema v1?
+ *
+ * @param {unknown} value
+ * @returns {value is StandardSchema}
+ */
+// eslint-disable-next-line import/prefer-default-export
+export const isStandardSchema = (value) => (
+	value !== null
+	&& typeof value === 'object'
+	&& '~standard' in value
+	&& typeof (/** @type {{ '~standard'?: { validate?: unknown } }} */ (value))['~standard']?.validate === 'function'
+);

--- a/src/lib/core/standard-schema.js
+++ b/src/lib/core/standard-schema.js
@@ -47,7 +47,8 @@
  */
 
 /**
- * Duck-typed guard: does `value` implement Standard Schema v1?
+ * Duck-typed guard: does `value` implement Standard Schema v1? Objects and
+ * functions alike — ArkType's `Type` is a callable carrying `~standard`.
  *
  * @param {unknown} value
  * @returns {value is StandardSchema}
@@ -55,7 +56,7 @@
 // eslint-disable-next-line import/prefer-default-export
 export const isStandardSchema = (value) => (
 	value !== null
-	&& typeof value === 'object'
+	&& (typeof value === 'object' || typeof value === 'function')
 	&& '~standard' in value
 	&& typeof (/** @type {{ '~standard'?: { validate?: unknown } }} */ (value))['~standard']?.validate === 'function'
 );

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -3,36 +3,36 @@ export { default as Field } from './Field';
 export { default as FieldError } from './FieldError';
 export * from './Form';
 export { default, default as Form } from './Form';
-// Standard Schema groundwork (RFC 0001): the vendored spec and the
-// normalized `FormError` protocol. Types reach consumers through these
-// star exports (a JS module cannot `export type`); the AJV provider itself
-// is deliberately NOT re-exported here — it lives on the
-// `react-jsonschema-form-validation/providers/ajv` subpath so consumers of
-// other Standard Schema providers never bundle AJV.
-export * from './core/standard-schema';
-export * from './core/errors';
 
-/**
- * Public type surface, re-declared here so the per-file `.d.ts` build keeps
- * exporting from the root exactly what the former bundled `index.d.ts`
- * hoisted (a JS module cannot `export type`; a JSDoc typedef aliasing an
- * `import()` type is the equivalent). Runtime surface unchanged.
- *
- * @import { ElementType } from 'react'
- *
- * @typedef {import('./Form/Context.types').AjvKeyword} AjvKeyword
- * @typedef {import('./Form/Context.types').ErrorMessageFn} ErrorMessageFn
- * @typedef {import('./Form/Context.types').ErrorMessagesMap} ErrorMessagesMap
- * @typedef {import('./Form/Context.types').FormContextValue} FormContextValue
- * @typedef {import('./Form/helpers').FormattedError} FormattedError
- * @typedef {import('./Form/helpers').FormChangeEvent} FormChangeEvent
- * @typedef {import('./Form/helpers').FormInputTarget} FormInputTarget
- * @typedef {import('./Form/Form').FormBaseProps} FormBaseProps
- * @typedef {import('./Form/Form').JfvScrollOptions} JfvScrollOptions
- * @typedef {import('./Field/Field').FieldBaseProps} FieldBaseProps
- * @typedef {import('./Field/Field').FieldChangeHandler} FieldChangeHandler
- * @typedef {import('./FieldError/FieldError').FieldErrorBaseProps} FieldErrorBaseProps
- */
+// Public type surface, re-declared here so the per-file `.d.ts` build keeps
+// exporting from the root exactly what the former bundled `index.d.ts`
+// hoisted, plus the Standard Schema groundwork types (RFC 0001). A JS
+// module cannot `export type`; a JSDoc typedef aliasing an `import()` type
+// is the equivalent. Runtime surface unchanged: the core protocol
+// functions stay internal until the `/core` entry lands with `useForm`,
+// and the AJV provider lives on its own subpath
+// (`react-jsonschema-form-validation/providers/ajv`) so consumers of other
+// Standard Schema providers never bundle AJV.
+
+/** @import { ElementType } from 'react' */
+
+/** @typedef {import('./Form/Context.types').AjvKeyword} AjvKeyword */
+/** @typedef {import('./Form/Context.types').ErrorMessageFn} ErrorMessageFn */
+/** @typedef {import('./Form/Context.types').ErrorMessagesMap} ErrorMessagesMap */
+/** @typedef {import('./Form/Context.types').FormContextValue} FormContextValue */
+/** @typedef {import('./Form/helpers').FormattedError} FormattedError */
+/** @typedef {import('./Form/helpers').FormChangeEvent} FormChangeEvent */
+/** @typedef {import('./Form/helpers').FormInputTarget} FormInputTarget */
+/** @typedef {import('./Form/Form').FormBaseProps} FormBaseProps */
+/** @typedef {import('./Form/Form').JfvScrollOptions} JfvScrollOptions */
+/** @typedef {import('./Field/Field').FieldBaseProps} FieldBaseProps */
+/** @typedef {import('./Field/Field').FieldChangeHandler} FieldChangeHandler */
+/** @typedef {import('./FieldError/FieldError').FieldErrorBaseProps} FieldErrorBaseProps */
+
+/** @typedef {import('./core/errors').FormError} FormError */
+/** @typedef {import('./core/errors').ErrorCode} ErrorCode */
+/** @typedef {import('./core/errors').ProviderIssue} ProviderIssue */
+/** @typedef {import('./core/standard-schema').StandardSchemaIssue} StandardSchemaIssue */
 
 /**
  * @template T
@@ -54,4 +54,22 @@ export * from './core/errors';
 /**
  * @template {ElementType} [C = 'div']
  * @typedef {import('./FieldError/FieldError').FieldErrorProps<C>} FieldErrorProps
+ */
+
+/**
+ * @template Output
+ * @typedef {import('./core/standard-schema').StandardSchemaResult<Output>} StandardSchemaResult
+ */
+
+/**
+ * @template [Input = unknown]
+ * @template [Output = Input]
+ * @typedef {import('./core/standard-schema').StandardSchemaProps<Input, Output>
+ * } StandardSchemaProps
+ */
+
+/**
+ * @template [Input = unknown]
+ * @template [Output = Input]
+ * @typedef {import('./core/standard-schema').StandardSchema<Input, Output>} StandardSchema
  */

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -3,3 +3,55 @@ export { default as Field } from './Field';
 export { default as FieldError } from './FieldError';
 export * from './Form';
 export { default, default as Form } from './Form';
+// Standard Schema groundwork (RFC 0001): the vendored spec and the
+// normalized `FormError` protocol. Types reach consumers through these
+// star exports (a JS module cannot `export type`); the AJV provider itself
+// is deliberately NOT re-exported here — it lives on the
+// `react-jsonschema-form-validation/providers/ajv` subpath so consumers of
+// other Standard Schema providers never bundle AJV.
+export * from './core/standard-schema';
+export * from './core/errors';
+
+/**
+ * Public type surface, re-declared here so the per-file `.d.ts` build keeps
+ * exporting from the root exactly what the former bundled `index.d.ts`
+ * hoisted (a JS module cannot `export type`; a JSDoc typedef aliasing an
+ * `import()` type is the equivalent). Runtime surface unchanged.
+ *
+ * @import { ElementType } from 'react'
+ *
+ * @typedef {import('./Form/Context.types').AjvKeyword} AjvKeyword
+ * @typedef {import('./Form/Context.types').ErrorMessageFn} ErrorMessageFn
+ * @typedef {import('./Form/Context.types').ErrorMessagesMap} ErrorMessagesMap
+ * @typedef {import('./Form/Context.types').FormContextValue} FormContextValue
+ * @typedef {import('./Form/helpers').FormattedError} FormattedError
+ * @typedef {import('./Form/helpers').FormChangeEvent} FormChangeEvent
+ * @typedef {import('./Form/helpers').FormInputTarget} FormInputTarget
+ * @typedef {import('./Form/Form').FormBaseProps} FormBaseProps
+ * @typedef {import('./Form/Form').JfvScrollOptions} JfvScrollOptions
+ * @typedef {import('./Field/Field').FieldBaseProps} FieldBaseProps
+ * @typedef {import('./Field/Field').FieldChangeHandler} FieldChangeHandler
+ * @typedef {import('./FieldError/FieldError').FieldErrorBaseProps} FieldErrorBaseProps
+ */
+
+/**
+ * @template T
+ * @template {PropertyKey} K
+ * @typedef {import('./Form/helpers').SafePropsOmit<T, K>} SafePropsOmit
+ */
+
+/**
+ * @template [T = Record<string, unknown>]
+ * @template {ElementType} [C = 'form']
+ * @typedef {import('./Form/Form').FormProps<T, C>} FormProps
+ */
+
+/**
+ * @template {ElementType} [C = 'input']
+ * @typedef {import('./Field/Field').FieldProps<C>} FieldProps
+ */
+
+/**
+ * @template {ElementType} [C = 'div']
+ * @typedef {import('./FieldError/FieldError').FieldErrorProps<C>} FieldErrorProps
+ */

--- a/src/lib/providers/ajv/index.js
+++ b/src/lib/providers/ajv/index.js
@@ -1,0 +1,132 @@
+/**
+ * AJV provider: wraps a JSON Schema into a Standard Schema v1 object, so a
+ * JSON Schema speaks the same protocol as Zod / Valibot / ArkType. Ships as
+ * its own entry (`react-jsonschema-form-validation/providers/ajv`) so
+ * consumers of other providers never bundle AJV.
+ *
+ * Not wired into `<Form>` yet — the class component keeps its direct AJV
+ * path until `useForm` lands (RFC 0001, PR 3).
+ *
+ * @import { ErrorObject } from 'ajv'
+ * @import { JSONSchema7Definition } from 'json-schema'
+ * @import { StandardSchema } from '../../core/standard-schema'
+ * @import { ProviderIssue } from '../../core/errors'
+ */
+
+import {
+	createAjv,
+	dataPathToFieldPath,
+	formatData,
+	pointerToSegments,
+} from '../../Form/helpers';
+
+// Re-exported so a custom instance can be built from the subpath alone:
+// `import { ajvSchema, createAjv } from '…/providers/ajv'`.
+export { createAjv };
+
+/**
+ * Anything exposing `compile(schema)` — the provider never relies on the
+ * exact Ajv class (`Ajv2019` / `Ajv2020` instances are fine).
+ *
+ * @typedef {{
+ *   compile: (schema: any) =>
+ *     ((data: unknown) => boolean | Promise<unknown>) & { errors?: ErrorObject[] | null },
+ * }} AjvLike
+ */
+
+/**
+ * AJV keyword → normalized code (RFC 0001). Everything else passes through
+ * under its own keyword (`oneOf`, `multipleOf`, `uniqueItems`, `minItems`…).
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const AJV_CODE_MAP = Object.freeze({
+	minimum: 'min',
+	exclusiveMinimum: 'min',
+	maximum: 'max',
+	exclusiveMaximum: 'max',
+});
+
+/**
+ * Path segments of an AJV error: `instancePath` (AJV 8, JSON Pointer) when
+ * present, legacy `dataPath` (AJV 6, dot/bracket notation) otherwise;
+ * `required` errors point at the missing property itself.
+ *
+ * @param {ErrorObject & { dataPath?: string }} error
+ * @returns {string[]}
+ */
+export const errorToSegments = (error) => {
+	/** @type {string[]} */
+	let segments;
+	if (typeof error.instancePath === 'string') {
+		segments = pointerToSegments(error.instancePath);
+	} else {
+		const field = dataPathToFieldPath(error.dataPath ?? '');
+		segments = field === '' ? [] : field.split('.');
+	}
+	if (error.keyword === 'required' && 'missingProperty' in error.params) {
+		return [...segments, String(error.params.missingProperty)];
+	}
+	return segments;
+};
+
+/**
+ * @param {ErrorObject} error
+ * @returns {ProviderIssue}
+ */
+export const errorToIssue = (error) => ({
+	message: error.message ?? '',
+	path: errorToSegments(error),
+	code: AJV_CODE_MAP[error.keyword] ?? error.keyword,
+	params: error.params,
+	raw: error,
+});
+
+/** @type {ReturnType<typeof createAjv> | undefined} */
+let defaultAjv;
+const getDefaultAjv = () => {
+	if (!defaultAjv) defaultAjv = createAjv();
+	return defaultAjv;
+};
+
+/**
+ * Wraps a JSON Schema into a Standard Schema object backed by AJV. The
+ * schema is compiled once, here: memoize the returned object per
+ * `(schema, ajv)` pair when calling from a render.
+ *
+ * `validate(data)` normalizes empty form values first (`''` / `null` →
+ * `undefined`, so `required` flags them — see `formatData`), then reports
+ * every AJV error as an issue carrying the normalized `code`, the AJV
+ * `params` and the verbose `ErrorObject` as `raw` (`raw.data` = current
+ * value of the field, issue #6).
+ *
+ * @template [T = unknown]
+ * @param {JSONSchema7Definition} schema
+ * @param {{ ajv?: AjvLike }} [options] `ajv`: a custom AJV 8 instance (must
+ *   register `ajv-formats` itself if it relies on string formats).
+ * @returns {StandardSchema<T> & { jsonSchema: JSONSchema7Definition }}
+ */
+export const ajvSchema = (schema, options = {}) => {
+	const ajv = options.ajv ?? getDefaultAjv();
+	if (!ajv || typeof ajv.compile !== 'function') {
+		throw new Error(
+			'react-jsonschema-form-validation: `ajv` must be an AJV-like instance exposing '
+			+ `a compile(schema) function, received ${typeof ajv}.`,
+		);
+	}
+	const validate = ajv.compile(schema);
+	return {
+		jsonSchema: schema,
+		'~standard': {
+			version: 1,
+			vendor: 'ajv',
+			validate: (data) => {
+				const formatted = formatData(data);
+				// Async schemas are not used: the result is a boolean.
+				const valid = /** @type {boolean} */ (validate(formatted));
+				if (valid) return { value: /** @type {T} */ (formatted) };
+				return { issues: (validate.errors || []).map(errorToIssue) };
+			},
+		},
+	};
+};

--- a/src/lib/providers/ajv/index.js
+++ b/src/lib/providers/ajv/index.js
@@ -13,6 +13,7 @@
  * @import { ProviderIssue } from '../../core/errors'
  */
 
+import { assertSyncResult, SYNC_ONLY_ERROR_MESSAGE } from '../../core/errors';
 import {
 	createAjv,
 	dataPathToFieldPath,
@@ -26,10 +27,12 @@ export { createAjv };
 
 /**
  * Anything exposing `compile(schema)` — the provider never relies on the
- * exact Ajv class (`Ajv2019` / `Ajv2020` instances are fine).
+ * exact Ajv class (`Ajv2019` / `Ajv2020` instances are fine). Method
+ * signature on purpose: methods are bivariant, so the real `Ajv` class
+ * (whose `compile` takes `AnySchema`) stays assignable.
  *
  * @typedef {{
- *   compile: (schema: any) =>
+ *   compile(schema: unknown):
  *     ((data: unknown) => boolean | Promise<unknown>) & { errors?: ErrorObject[] | null },
  * }} AjvLike
  */
@@ -40,7 +43,7 @@ export { createAjv };
  *
  * @type {Readonly<Record<string, string>>}
  */
-export const AJV_CODE_MAP = Object.freeze({
+const AJV_CODE_MAP = Object.freeze({
 	minimum: 'min',
 	exclusiveMinimum: 'min',
 	maximum: 'max',
@@ -55,7 +58,7 @@ export const AJV_CODE_MAP = Object.freeze({
  * @param {ErrorObject & { dataPath?: string }} error
  * @returns {string[]}
  */
-export const errorToSegments = (error) => {
+const errorToSegments = (error) => {
 	/** @type {string[]} */
 	let segments;
 	if (typeof error.instancePath === 'string') {
@@ -74,7 +77,7 @@ export const errorToSegments = (error) => {
  * @param {ErrorObject} error
  * @returns {ProviderIssue}
  */
-export const errorToIssue = (error) => ({
+const errorToIssue = (error) => ({
 	message: error.message ?? '',
 	path: errorToSegments(error),
 	code: AJV_CODE_MAP[error.keyword] ?? error.keyword,
@@ -94,11 +97,17 @@ const getDefaultAjv = () => {
  * schema is compiled once, here: memoize the returned object per
  * `(schema, ajv)` pair when calling from a render.
  *
+ * Without `ajv`, a single default instance (`createAjv()`) is shared by
+ * every call, as the 0.x `<Form>` did: two different schemas declaring the
+ * same `$id` therefore collide at compile time (AJV throws) — pass a
+ * dedicated instance in that case.
+ *
  * `validate(data)` normalizes empty form values first (`''` / `null` →
  * `undefined`, so `required` flags them — see `formatData`), then reports
  * every AJV error as an issue carrying the normalized `code`, the AJV
  * `params` and the verbose `ErrorObject` as `raw` (`raw.data` = current
- * value of the field, issue #6).
+ * value of the field, issue #6). An `$async: true` schema makes AJV return
+ * a Promise instead of a boolean: rejected with the sync-only error.
  *
  * @template [T = unknown]
  * @param {JSONSchema7Definition} schema
@@ -122,8 +131,14 @@ export const ajvSchema = (schema, options = {}) => {
 			vendor: 'ajv',
 			validate: (data) => {
 				const formatted = formatData(data);
-				// Async schemas are not used: the result is a boolean.
-				const valid = /** @type {boolean} */ (validate(formatted));
+				const valid = validate(formatted);
+				if (typeof valid !== 'boolean') {
+					// A Promise (`$async` schema) is caught — and its rejection
+					// swallowed — by the shared guard; anything else non-boolean
+					// is equally unusable as a synchronous verdict.
+					assertSyncResult(valid);
+					throw new Error(SYNC_ONLY_ERROR_MESSAGE);
+				}
 				if (valid) return { value: /** @type {T} */ (formatted) };
 				return { issues: (validate.errors || []).map(errorToIssue) };
 			},

--- a/src/lib/providers/ajv/index.test.js
+++ b/src/lib/providers/ajv/index.test.js
@@ -1,18 +1,23 @@
 import Ajv2020 from 'ajv/dist/2020';
 
-import { runSchema } from '../../core/errors';
+import { runSchema, SYNC_ONLY_ERROR_MESSAGE } from '../../core/errors';
 import { isStandardSchema } from '../../core/standard-schema';
 import { createAjv as createAjvFromHelpers } from '../../Form/helpers';
-import {
-	AJV_CODE_MAP,
-	ajvSchema,
-	createAjv,
-	errorToIssue,
-	errorToSegments,
-} from '.';
+import { ajvSchema, createAjv } from '.';
 
 const run = (schema, data, options) => runSchema(ajvSchema(schema, options), data);
 const codesByKeyword = (errors) => Object.fromEntries(errors.map((e) => [e.raw.keyword, e.code]));
+
+// A compile-capable stub whose validator always fails with the given raw
+// AJV-shaped errors — lets the tests feed hand-crafted error objects
+// (legacy AJV 6 shape, edge cases) through the public `ajvSchema()` path.
+const stubAjv = (errors) => ({
+	compile: () => {
+		const validate = () => false;
+		validate.errors = errors;
+		return validate;
+	},
+});
 
 describe('ajvSchema(schema, { ajv })', () => {
 	it('should return a Standard Schema object backed by AJV, keeping the JSON Schema', () => {
@@ -82,6 +87,34 @@ describe('validate(data) — value normalization', () => {
 		const data = { email: '', age: 1 };
 		run(schema, data);
 		expect(data).toEqual({ email: '', age: 1 });
+	});
+});
+
+describe('validate(data) — sync-only', () => {
+	it('should throw the sync-only error on an $async schema and not leak a rejection', async () => {
+		const unhandled = vi.fn();
+		process.on('unhandledRejection', unhandled);
+		try {
+			// `$async: true` makes AJV return a Promise (rejected on invalid data).
+			const schema = ajvSchema({
+				$async: true,
+				type: 'object',
+				properties: { a: { type: 'number' } },
+			});
+			expect(() => schema['~standard'].validate({ a: 'not a number' })).toThrow(SYNC_ONLY_ERROR_MESSAGE);
+			expect(() => schema['~standard'].validate({ a: 1 })).toThrow(SYNC_ONLY_ERROR_MESSAGE);
+			// Let the rejected promise settle: the handler attached by the guard
+			// must have consumed the rejection.
+			await new Promise((resolve) => { setTimeout(resolve, 0); });
+			expect(unhandled).not.toHaveBeenCalled();
+		} finally {
+			process.off('unhandledRejection', unhandled);
+		}
+	});
+
+	it('should throw the sync-only error when the validator returns a non-boolean', () => {
+		const ajv = { compile: () => () => 'yes' };
+		expect(() => ajvSchema({}, { ajv })['~standard'].validate({})).toThrow(SYNC_ONLY_ERROR_MESSAGE);
 	});
 });
 
@@ -158,7 +191,8 @@ describe('error normalization — keyword → code', () => {
 		const { errors } = run(schema, data);
 		const byField = Object.fromEntries(errors.map((e) => [e.field, e]));
 		expect(byField.min.params).toEqual({ comparison: '>=', limit: 5 });
-		expect(byField.min.message).toBe('must be >= 5');
+		expect(byField.min.message).toBe(byField.min.raw.message);
+		expect(byField.min.message).not.toBe('');
 		expect(byField.req.params).toEqual({ missingProperty: 'req' });
 		expect(byField.enm.params).toEqual({ allowedValues: ['a'] });
 		expect(byField.min.raw).toMatchObject({ keyword: 'minimum', instancePath: '/min' });
@@ -173,11 +207,15 @@ describe('error normalization — keyword → code', () => {
 		expect(byField.req.raw.data).toMatchObject({ typ: 'x' });
 	});
 
-	it('should expose the code map as a frozen object', () => {
-		expect(Object.isFrozen(AJV_CODE_MAP)).toBe(true);
-		expect(AJV_CODE_MAP).toEqual({
-			minimum: 'min', exclusiveMinimum: 'min', maximum: 'max', exclusiveMaximum: 'max',
-		});
+	it('should keep the raw AJV error object by reference (no copy)', () => {
+		const rawError = {
+			keyword: 'maximum', instancePath: '/n', params: { limit: 1 }, message: 'too big',
+		};
+		const { errors } = run({}, {}, { ajv: stubAjv([rawError]) });
+		expect(errors).toEqual([{
+			field: 'n', code: 'max', message: 'too big', params: { limit: 1 }, raw: rawError,
+		}]);
+		expect(errors[0].raw).toBe(rawError);
 	});
 });
 
@@ -222,21 +260,24 @@ describe('error normalization — field paths', () => {
 	it('should map a root-level error to the empty field', () => {
 		expect(run({ type: 'object' }, 42).errors.map((e) => [e.field, e.code])).toEqual([['', 'type']]);
 	});
+
+	it('should append missingProperty only for required errors', () => {
+		const { errors } = run({}, {}, {
+			ajv: stubAjv([
+				{ keyword: 'required', instancePath: '/a', params: { missingProperty: 'b' } },
+				{ keyword: 'required', instancePath: '', params: { missingProperty: 'b' } },
+				{ keyword: 'required', instancePath: '/a', params: {} },
+				{ keyword: 'type', instancePath: '/a', params: { missingProperty: 'b' } },
+			]),
+		});
+		expect(errors.map((e) => e.field)).toEqual(['a.b', 'b', 'a', 'a']);
+	});
 });
 
 describe('legacy AJV 6 error shape (dataPath fallback)', () => {
-	// A compile-capable stub emitting AJV-6-shaped errors (no instancePath).
-	const legacyAjv = (errors) => ({
-		compile: () => {
-			const validate = () => false;
-			validate.errors = errors;
-			return validate;
-		},
-	});
-
 	it('should read dataPath (dot/bracket notation) when instancePath is absent', () => {
 		const { errors } = run({}, {}, {
-			ajv: legacyAjv([
+			ajv: stubAjv([
 				{
 					keyword: 'minLength', dataPath: '.items[0].label', params: { limit: 2 }, message: 'short',
 				},
@@ -254,31 +295,8 @@ describe('legacy AJV 6 error shape (dataPath fallback)', () => {
 	});
 
 	it('should default the message to an empty string when the error has none', () => {
-		const { errors } = run({}, {}, { ajv: legacyAjv([{ keyword: 'type', params: {} }]) });
+		const { errors } = run({}, {}, { ajv: stubAjv([{ keyword: 'type', params: {} }]) });
 		expect(errors[0].message).toBe('');
-	});
-});
-
-describe('errorToSegments / errorToIssue (unit)', () => {
-	it('should append missingProperty only for required errors', () => {
-		expect(errorToSegments({ keyword: 'required', instancePath: '/a', params: { missingProperty: 'b' } }))
-			.toEqual(['a', 'b']);
-		expect(errorToSegments({ keyword: 'required', instancePath: '', params: { missingProperty: 'b' } }))
-			.toEqual(['b']);
-		expect(errorToSegments({ keyword: 'required', instancePath: '/a', params: {} })).toEqual(['a']);
-		expect(errorToSegments({ keyword: 'type', instancePath: '/a', params: { missingProperty: 'b' } }))
-			.toEqual(['a']);
-	});
-
-	it('should build a provider issue with the mapped code and the error as raw', () => {
-		const error = {
-			keyword: 'maximum', instancePath: '/n', params: { limit: 1 }, message: 'too big',
-		};
-		const issue = errorToIssue(error);
-		expect(issue).toEqual({
-			message: 'too big', path: ['n'], code: 'max', params: { limit: 1 }, raw: error,
-		});
-		expect(issue.raw).toBe(error);
 	});
 });
 
@@ -312,13 +330,6 @@ describe('defensive branches', () => {
 	it('should report no issue when a failing validator exposes no errors array', () => {
 		// AJV always fills `errors` on failure; a custom compile-capable
 		// object might not. Treated as "no reported problem" rather than crashing.
-		const ajv = {
-			compile: () => {
-				const validate = () => false;
-				validate.errors = null;
-				return validate;
-			},
-		};
-		expect(ajvSchema({}, { ajv })['~standard'].validate({})).toEqual({ issues: [] });
+		expect(ajvSchema({}, { ajv: stubAjv(null) })['~standard'].validate({})).toEqual({ issues: [] });
 	});
 });

--- a/src/lib/providers/ajv/index.test.js
+++ b/src/lib/providers/ajv/index.test.js
@@ -1,0 +1,324 @@
+import Ajv2020 from 'ajv/dist/2020';
+
+import { runSchema } from '../../core/errors';
+import { isStandardSchema } from '../../core/standard-schema';
+import { createAjv as createAjvFromHelpers } from '../../Form/helpers';
+import {
+	AJV_CODE_MAP,
+	ajvSchema,
+	createAjv,
+	errorToIssue,
+	errorToSegments,
+} from '.';
+
+const run = (schema, data, options) => runSchema(ajvSchema(schema, options), data);
+const codesByKeyword = (errors) => Object.fromEntries(errors.map((e) => [e.raw.keyword, e.code]));
+
+describe('ajvSchema(schema, { ajv })', () => {
+	it('should return a Standard Schema object backed by AJV, keeping the JSON Schema', () => {
+		const jsonSchema = { type: 'object' };
+		const schema = ajvSchema(jsonSchema);
+		expect(isStandardSchema(schema)).toBe(true);
+		expect(schema['~standard'].version).toBe(1);
+		expect(schema['~standard'].vendor).toBe('ajv');
+		expect(schema.jsonSchema).toBe(jsonSchema);
+	});
+
+	it('should re-export createAjv from the subpath (same function as the helpers)', () => {
+		expect(createAjv).toBe(createAjvFromHelpers);
+	});
+
+	it('should throw a clear error when ajv does not expose compile()', () => {
+		expect(() => ajvSchema({}, { ajv: 42 })).toThrow(
+			'react-jsonschema-form-validation: `ajv` must be an AJV-like instance exposing '
+			+ 'a compile(schema) function, received number.',
+		);
+		expect(() => ajvSchema({}, { ajv: { notCompile: true } })).toThrow(/received object\./);
+		// `null` / `undefined` mean "not provided": the default instance is used
+		// (same leniency as the 0.x `ajv` prop).
+		expect(() => ajvSchema({}, { ajv: null })).not.toThrow();
+		expect(() => ajvSchema({}, { ajv: undefined })).not.toThrow();
+	});
+
+	it('should accept any compile-capable object and use it', () => {
+		const compile = vi.fn(() => () => true);
+		const schema = ajvSchema({ type: 'string' }, { ajv: { compile } });
+		expect(compile).toHaveBeenCalledWith({ type: 'string' });
+		expect(schema['~standard'].validate('x')).toEqual({ value: 'x' });
+	});
+
+	it('should work with a real draft 2020-12 Ajv instance', () => {
+		const ajv = new Ajv2020({ allErrors: true });
+		const schema = { type: 'array', prefixItems: [{ type: 'number' }], items: false };
+		expect(run(schema, [1], { ajv })).toEqual({ valid: true, errors: [] });
+		const { valid, errors } = run(schema, [1, 'extra'], { ajv });
+		expect(valid).toBe(false);
+		expect(errors.map((e) => [e.field, e.code])).toEqual([['', 'items']]);
+	});
+});
+
+describe('validate(data) — value normalization', () => {
+	const schema = {
+		type: 'object',
+		properties: { email: { type: 'string' }, age: { type: 'number' } },
+		required: ['email', 'age'],
+	};
+
+	it('should return the formatted value on success', () => {
+		const result = ajvSchema({ type: 'object' })['~standard'].validate({ a: '', b: null, c: 'x' });
+		expect(result).toEqual({ value: { a: undefined, b: undefined, c: 'x' } });
+	});
+
+	it('should treat empty strings and null as missing for `required` (formatData)', () => {
+		const { valid, errors } = run(schema, { email: '', age: null });
+		expect(valid).toBe(false);
+		expect(errors.map((e) => [e.field, e.code])).toEqual([
+			['email', 'required'],
+			['age', 'required'],
+		]);
+	});
+
+	it('should not mutate the input data', () => {
+		const data = { email: '', age: 1 };
+		run(schema, data);
+		expect(data).toEqual({ email: '', age: 1 });
+	});
+});
+
+describe('error normalization — keyword → code', () => {
+	const schema = {
+		type: 'object',
+		properties: {
+			req: { type: 'string' },
+			typ: { type: 'number' },
+			min: { type: 'number', minimum: 5 },
+			xmin: { type: 'number', exclusiveMinimum: 5 },
+			max: { type: 'number', maximum: 5 },
+			xmax: { type: 'number', exclusiveMaximum: 5 },
+			minLen: { type: 'string', minLength: 3 },
+			maxLen: { type: 'string', maxLength: 3 },
+			pat: { type: 'string', pattern: '^a' },
+			fmt: { type: 'string', format: 'email' },
+			enm: { type: 'string', enum: ['a'] },
+			cst: { type: 'string', const: 'a' },
+			mult: { type: 'number', multipleOf: 2 },
+			uniq: { type: 'array', uniqueItems: true },
+			minI: { type: 'array', minItems: 2 },
+			maxI: { type: 'array', maxItems: 1 },
+			one: { oneOf: [{ type: 'string' }, { type: 'number' }] },
+			addl: { type: 'object', additionalProperties: false },
+		},
+		required: ['req'],
+	};
+	const data = {
+		typ: 'x',
+		min: 1,
+		xmin: 5,
+		max: 9,
+		xmax: 5,
+		minLen: 'a',
+		maxLen: 'abcd',
+		pat: 'b',
+		fmt: 'nope',
+		enm: 'z',
+		cst: 'z',
+		mult: 3,
+		uniq: [1, 1],
+		minI: [1],
+		maxI: [1, 2],
+		one: true,
+		addl: { x: 1 },
+	};
+
+	it('should map the 9 core codes and pass every other keyword through', () => {
+		const { errors } = run(schema, data);
+		expect(codesByKeyword(errors)).toEqual({
+			required: 'required',
+			type: 'type',
+			minimum: 'min',
+			exclusiveMinimum: 'min',
+			maximum: 'max',
+			exclusiveMaximum: 'max',
+			minLength: 'minLength',
+			maxLength: 'maxLength',
+			pattern: 'pattern',
+			format: 'format',
+			enum: 'enum',
+			const: 'const',
+			multipleOf: 'multipleOf',
+			uniqueItems: 'uniqueItems',
+			minItems: 'minItems',
+			maxItems: 'maxItems',
+			oneOf: 'oneOf',
+			additionalProperties: 'additionalProperties',
+		});
+	});
+
+	it('should expose the AJV params, message and the verbose error as raw', () => {
+		const { errors } = run(schema, data);
+		const byField = Object.fromEntries(errors.map((e) => [e.field, e]));
+		expect(byField.min.params).toEqual({ comparison: '>=', limit: 5 });
+		expect(byField.min.message).toBe('must be >= 5');
+		expect(byField.req.params).toEqual({ missingProperty: 'req' });
+		expect(byField.enm.params).toEqual({ allowedValues: ['a'] });
+		expect(byField.min.raw).toMatchObject({ keyword: 'minimum', instancePath: '/min' });
+	});
+
+	it('should carry the current field value as raw.data (verbose mode, issue #6)', () => {
+		const { errors } = run(schema, data);
+		const byField = Object.fromEntries(errors.map((e) => [e.field, e]));
+		expect(byField.minLen.raw.data).toBe('a');
+		expect(byField.fmt.raw.data).toBe('nope');
+		// `required` is reported on the parent: raw.data is the parent object.
+		expect(byField.req.raw.data).toMatchObject({ typ: 'x' });
+	});
+
+	it('should expose the code map as a frozen object', () => {
+		expect(Object.isFrozen(AJV_CODE_MAP)).toBe(true);
+		expect(AJV_CODE_MAP).toEqual({
+			minimum: 'min', exclusiveMinimum: 'min', maximum: 'max', exclusiveMaximum: 'max',
+		});
+	});
+});
+
+describe('error normalization — field paths', () => {
+	it('should point required errors at the missing property, at the root and nested', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				user: { type: 'object', properties: { email: { type: 'string' } }, required: ['email'] },
+			},
+			required: ['user', 'other'],
+		};
+		expect(run(schema, {}).errors.map((e) => e.field)).toEqual(['user', 'other']);
+		expect(run(schema, { user: {}, other: 1 }).errors.map((e) => e.field)).toEqual(['user.email']);
+	});
+
+	it('should convert multi-index array pointers to dotted paths', () => {
+		const schema = {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { tags: { type: 'array', items: { type: 'string', minLength: 2 } } },
+				required: ['tags'],
+			},
+		};
+		const { errors } = run(schema, [{ tags: ['ok', 'x'] }, {}]);
+		expect(errors.map((e) => [e.field, e.code])).toEqual([
+			['0.tags.1', 'minLength'],
+			['1.tags', 'required'],
+		]);
+	});
+
+	it('should decode RFC 6901 escapes in pointer segments', () => {
+		const schema = {
+			type: 'object',
+			properties: { 'a/b': { type: 'number' }, 'c~d': { type: 'number' } },
+		};
+		const { errors } = run(schema, { 'a/b': 'x', 'c~d': 'x' });
+		expect(errors.map((e) => e.field)).toEqual(['a/b', 'c~d']);
+	});
+
+	it('should map a root-level error to the empty field', () => {
+		expect(run({ type: 'object' }, 42).errors.map((e) => [e.field, e.code])).toEqual([['', 'type']]);
+	});
+});
+
+describe('legacy AJV 6 error shape (dataPath fallback)', () => {
+	// A compile-capable stub emitting AJV-6-shaped errors (no instancePath).
+	const legacyAjv = (errors) => ({
+		compile: () => {
+			const validate = () => false;
+			validate.errors = errors;
+			return validate;
+		},
+	});
+
+	it('should read dataPath (dot/bracket notation) when instancePath is absent', () => {
+		const { errors } = run({}, {}, {
+			ajv: legacyAjv([
+				{
+					keyword: 'minLength', dataPath: '.items[0].label', params: { limit: 2 }, message: 'short',
+				},
+				{
+					keyword: 'required', dataPath: '.user', params: { missingProperty: 'email' }, message: 'missing',
+				},
+				{ keyword: 'type', params: { type: 'object' }, message: 'root' },
+			]),
+		});
+		expect(errors.map((e) => [e.field, e.code])).toEqual([
+			['items.0.label', 'minLength'],
+			['user.email', 'required'],
+			['', 'type'],
+		]);
+	});
+
+	it('should default the message to an empty string when the error has none', () => {
+		const { errors } = run({}, {}, { ajv: legacyAjv([{ keyword: 'type', params: {} }]) });
+		expect(errors[0].message).toBe('');
+	});
+});
+
+describe('errorToSegments / errorToIssue (unit)', () => {
+	it('should append missingProperty only for required errors', () => {
+		expect(errorToSegments({ keyword: 'required', instancePath: '/a', params: { missingProperty: 'b' } }))
+			.toEqual(['a', 'b']);
+		expect(errorToSegments({ keyword: 'required', instancePath: '', params: { missingProperty: 'b' } }))
+			.toEqual(['b']);
+		expect(errorToSegments({ keyword: 'required', instancePath: '/a', params: {} })).toEqual(['a']);
+		expect(errorToSegments({ keyword: 'type', instancePath: '/a', params: { missingProperty: 'b' } }))
+			.toEqual(['a']);
+	});
+
+	it('should build a provider issue with the mapped code and the error as raw', () => {
+		const error = {
+			keyword: 'maximum', instancePath: '/n', params: { limit: 1 }, message: 'too big',
+		};
+		const issue = errorToIssue(error);
+		expect(issue).toEqual({
+			message: 'too big', path: ['n'], code: 'max', params: { limit: 1 }, raw: error,
+		});
+		expect(issue.raw).toBe(error);
+	});
+});
+
+describe('default instance — $data and ajv-formats end-to-end', () => {
+	it('should resolve $data references (password confirmation)', () => {
+		const schema = {
+			type: 'object',
+			properties: {
+				password: { type: 'string' },
+				confirm: { type: 'string', const: { $data: '1/password' } },
+			},
+		};
+		expect(run(schema, { password: 's3cret', confirm: 's3cret' }).valid).toBe(true);
+		const { errors } = run(schema, { password: 's3cret', confirm: 'nope' });
+		expect(errors.map((e) => [e.field, e.code])).toEqual([['confirm', 'const']]);
+		expect(errors[0].raw.data).toBe('nope');
+	});
+
+	it('should validate string formats through ajv-formats', () => {
+		const schema = { type: 'object', properties: { email: { type: 'string', format: 'email' } } };
+		expect(run(schema, { email: 'hugo@53js.fr' }).valid).toBe(true);
+		expect(run(schema, { email: 'nope' }).errors.map((e) => [e.field, e.code])).toEqual([['email', 'format']]);
+	});
+
+	it('should tolerate unknown keywords (strict mode disabled on the default instance)', () => {
+		expect(() => ajvSchema({ type: 'string', notAKeyword: true })).not.toThrow();
+	});
+});
+
+describe('defensive branches', () => {
+	it('should report no issue when a failing validator exposes no errors array', () => {
+		// AJV always fills `errors` on failure; a custom compile-capable
+		// object might not. Treated as "no reported problem" rather than crashing.
+		const ajv = {
+			compile: () => {
+				const validate = () => false;
+				validate.errors = null;
+				return validate;
+			},
+		};
+		expect(ajvSchema({}, { ajv })['~standard'].validate({})).toEqual({ issues: [] });
+	});
+});

--- a/test-types/positive.tsx
+++ b/test-types/positive.tsx
@@ -35,8 +35,18 @@ import type {
 	SafePropsOmit,
 } from 'react-jsonschema-form-validation';
 
+import Ajv from 'ajv';
+import Ajv2020 from 'ajv/dist/2020';
 import { ajvSchema, createAjv } from 'react-jsonschema-form-validation/providers/ajv';
-import type { ErrorCode, FormError, StandardSchema } from 'react-jsonschema-form-validation';
+import type {
+	ErrorCode,
+	FormError,
+	ProviderIssue,
+	StandardSchema,
+	StandardSchemaIssue,
+	StandardSchemaProps,
+	StandardSchemaResult,
+} from 'react-jsonschema-form-validation';
 
 import { Expect, Equal } from './_helpers';
 
@@ -370,6 +380,19 @@ type _AllTypesResolve = {
 const standard: StandardSchema<UserData> = ajvSchema<UserData>(schema, { ajv: createAjv() });
 const _issues = standard['~standard'].validate({ email: 'nope', age: -1 });
 void _issues;
+
+// Real Ajv classes (draft-07 default and 2020-12) are assignable to the
+// `ajv` option — `AjvLike.compile` is a method signature (bivariant).
+const _ajv2020 = ajvSchema(schema, { ajv: new Ajv2020() });
+const _ajvDefault = ajvSchema(schema, { ajv: new Ajv() });
+void [_ajv2020, _ajvDefault];
+
+// The spec types are exported from the root too.
+const _issue: StandardSchemaIssue = { message: 'x', path: ['email', { key: 0 }] };
+const _result: StandardSchemaResult<UserData> = { issues: [_issue] };
+const _props: StandardSchemaProps<UserData> = standard['~standard'];
+const _providerIssue: ProviderIssue = { message: 'x', code: 'min', params: { limit: 1 } };
+void [_result, _props, _providerIssue];
 
 const _formError = (err: FormError) => {
 	const code: ErrorCode = err.code;

--- a/test-types/positive.tsx
+++ b/test-types/positive.tsx
@@ -35,6 +35,9 @@ import type {
 	SafePropsOmit,
 } from 'react-jsonschema-form-validation';
 
+import { ajvSchema, createAjv } from 'react-jsonschema-form-validation/providers/ajv';
+import type { ErrorCode, FormError, StandardSchema } from 'react-jsonschema-form-validation';
+
 import { Expect, Equal } from './_helpers';
 
 type UserData = { email: string; age: number };
@@ -360,6 +363,31 @@ type _AllTypesResolve = {
 	safeOmit: SafePropsOmit<{ a: string; [k: string]: unknown }, 'a'>;
 };
 
+// ---------------------------------------------------------------------------
+// 12. providers/ajv subpath (RFC 0001) — resolves under moduleResolution: node
+//     through `typesVersions`; core types come from the root entry.
+// ---------------------------------------------------------------------------
+const standard: StandardSchema<UserData> = ajvSchema<UserData>(schema, { ajv: createAjv() });
+const _issues = standard['~standard'].validate({ email: 'nope', age: -1 });
+void _issues;
+
+const _formError = (err: FormError) => {
+	const code: ErrorCode = err.code;
+	const field: string = err.field;
+	const params: Record<string, unknown> = err.params;
+	void [code, field, params, err.raw, err.message];
+};
+void _formError;
+
+// ErrorCode keeps the 9 normalized literals AND accepts any provider code.
+const _knownCode: ErrorCode = 'minLength';
+const _providerCode: ErrorCode = 'multipleOf';
+void [_knownCode, _providerCode];
+type _CoreCodesAssignable = Expect<Equal<'min' extends ErrorCode ? true : false, true>>;
+
+// The default AJV instance of createAjv() is AJV 8 (compile-capable).
+type _CreateAjvCompiles = Expect<Equal<'compile' extends keyof ReturnType<typeof createAjv> ? true : false, true>>;
+
 export {
 	Basic,
 	KeepStateOnSubmit,
@@ -375,4 +403,5 @@ export {
 };
 export type {
 	_CtxNonNull, _ErrMapValuesAreFns, _AllTypesResolve, _ResetIsNiladicVoid,
+	_CoreCodesAssignable, _CreateAjvCompiles,
 };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,6 @@
 		"emitDeclarationOnly": true,
 		"removeComments": false,
 		"rootDir": "src/lib",
-		"outDir": ".types-temp"
+		"outDir": "dist"
 	}
 }

--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -38,7 +38,15 @@ export default defineConfig({
 		// Consumers minify in their own bundler.
 		minify: false,
 		lib: {
-			entry: path.resolve(projectRoot, 'src/lib/index.js'),
+			// Multi-entry: the provider subpath is not imported by the root
+			// entry (consumers of other Standard Schema providers must not
+			// bundle AJV), so it needs its own entry to be emitted at all.
+			// With `preserveModules` the two graphs share their common
+			// modules (Form/helpers) as single files.
+			entry: {
+				index: path.resolve(projectRoot, 'src/lib/index.js'),
+				'providers/ajv/index': path.resolve(projectRoot, 'src/lib/providers/ajv/index.js'),
+			},
 			formats: ['es'],
 			// Emit .js (not Vite's default .mjs for an ES build): the
 			// package has always published dist/**/*.js and the exports

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,15 +1352,6 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-cliui@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
-  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^7.0.0"
-
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
@@ -1603,14 +1594,6 @@ dom-helpers@^3.4.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dts-bundle-generator@^9.5.1:
-  version "9.5.1"
-  resolved "https://registry.yarnpkg.com/dts-bundle-generator/-/dts-bundle-generator-9.5.1.tgz#7eac7f47a2d5b51bdaf581843e7f969b88bfc225"
-  integrity sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA==
-  dependencies:
-    typescript ">=5.0.2"
-    yargs "^17.6.0"
-
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
@@ -1747,7 +1730,7 @@ esbuild@^0.25.0:
     "@esbuild/win32-ia32" "0.25.12"
     "@esbuild/win32-x64" "0.25.12"
 
-escalade@^3.1.1, escalade@^3.2.0:
+escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
@@ -2109,11 +2092,6 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
-
-get-caller-file@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
-  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.2.6:
   version "1.3.0"
@@ -3282,11 +3260,6 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
@@ -3550,8 +3523,7 @@ std-env@^3.9.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.0, string-width@^4.2.3:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3826,7 +3798,7 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-typescript@>=5.0.2, typescript@^6.0.3:
+typescript@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
@@ -3984,8 +3956,7 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -4030,11 +4001,6 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -4047,20 +4013,7 @@ yaml@^1.7.2:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
-yargs-parser@^21.1.1:
-  version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
-  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
-yargs@^17.6.0:
-  version "17.7.3"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
-  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
+zod@^4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary

Second PR of the RFC 0001 sequence (#58), extracted from the accepted POC (#89). **Additive only**: the Standard Schema groundwork of the core and the AJV provider on its own subpath. The class `<Form>` is untouched and keeps its direct AJV path; nothing is wired — that lands with `useForm` (PR 3).

## Public surface

| Entry | Runtime | Types |
|---|---|---|
| `react-jsonschema-form-validation` (root) | `isStandardSchema`, `pathToField`, `normalizeIssues`, `assertSyncResult`, `runSchema` (the core protocol; no provider import) | `StandardSchema`, `StandardSchemaIssue`, `StandardSchemaResult`, `StandardSchemaProps`, `FormError`, `ErrorCode`, `ProviderIssue` + the 0.x types unchanged (`FormProps`, `FieldProps`, `FormContextValue`, `FormattedError`, …) |
| `react-jsonschema-form-validation/providers/ajv` (new) | `ajvSchema(jsonSchema, { ajv })`, `createAjv` (re-exported), `AJV_CODE_MAP`, `errorToSegments`, `errorToIssue` | `AjvLike` |

- `FormError = { field, code, message, params, raw }` — `field` dot-path (`''` at the root), `code` one of the 9 normalized codes (`required|type|min|max|minLength|maxLength|pattern|format|enum`) or the provider's own, `raw` the untouched provider error (AJV verbose → `raw.data` is the current field value, issue #6).
- `ErrorCode` = the 9 literals + `(string & {})` (autocomplete kept, any provider code accepted).
- AJV mapping: `minimum|exclusiveMinimum → min`, `maximum|exclusiveMaximum → max`, everything else passes through (`const`, `multipleOf`, `uniqueItems`, `minItems`/`maxItems`, `oneOf`, `additionalProperties` — the documented boundary). `required` → path = `instancePath` + `params.missingProperty`. Legacy AJV 6 `dataPath` errors still resolve (fallback shared with `formatErrors`).
- `Form/helpers.js`: two named exports added and reused by both `formatErrors` and the provider — `pointerToSegments` (RFC 6901 decoding, `pointerToFieldPath` now derives from it) and `dataPathToFieldPath` (extracted from `formatErrors`). No behavior change (helpers suite untouched and green).

## Design notes

- **Multi-entry Vite build**: the provider is not imported by the root entry (consumers of Zod/Valibot must never bundle AJV), so `preserveModules` alone would not emit it — `lib.entry` now lists `index` and `providers/ajv/index`; shared modules (`Form/helpers`) stay single files (`dist/providers/ajv/index.js` imports `../../Form/helpers.js`).
- **Per-file `.d.ts`** (`tsc -p tsconfig.build.json` → `dist/`): dts-bundle-generator cannot follow the subpath entry and inlined/hoisted types unpredictably. Consequence handled: the root used to export every hoisted type; `src/lib/index.js` now re-declares that surface explicitly (JSDoc typedef aliases of `import()` types — the JS equivalent of `export type`), so the public type names are unchanged. `dts-bundle-generator` devDep + its TypeScript resolution removed; `dist:types` is a single script.
- **`typesVersions`** next to `exports['./providers/ajv']`: `moduleResolution: node` consumers (and `test-types`) ignore `exports`; the map makes `import … from '…/providers/ajv'` resolve its `.d.ts` there too.
- **Sync-only**: `runSchema` throws an explicit error when `validate()` returns a Promise/thenable (RFC "Sync-only in v1").
- `ajvSchema` compiles once at call time and throws a clear error on a non-compile-capable `ajv`; `null`/`undefined` mean "use the default instance" (same leniency as the 0.x `ajv` prop). The default instance is created lazily, once.
- `zod@4` is a **devDependency only**: `core/errors.test.js` exercises a real third-party Standard Schema (nested paths, codes passed through).

## Verification

- `yarn lint && yarn type-check && yarn test:runtime && yarn dist`: clean — **11 files, 217 tests** (175 existing + 42 new).
- Coverage (`yarn test:runtime --coverage`), new files at 100 % on every column, existing files identical to the v1 baseline (98.85 / 88.26 / 100 / 99.37 → all files now 99 / 90.94 / 100 / 99.44):

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| core/errors.js | 100 | 100 | 100 | 100 |
| core/standard-schema.js | 100 | 100 | 100 | 100 |
| providers/ajv/index.js | 100 | 100 | 100 | 100 |
| Form/helpers.js | 100 | 100 | 100 | 100 |
| Form/Form.js · Field.js · FieldError.js · Context.js · setIn.js · throttle.js · a11y.js · getErrorMessage.js | unchanged from baseline |

- Every new test mutation-proven: 20 targeted mutations (path joining, `{ key }` unwrap, `unknown` code, params default, raw fallback, Promise + thenable guards, empty-issues, code map, frozen map, `required` path, `dataPath` fallback, `formatData`, compile guard, message default, code lookup, `raw.data`, vendor, bracket notation, null `errors`) → each fails the suite for the right reason, each reverted by the inverse edit, file checksums restored, `git diff` clean before commit.
- `yarn test:types`: green on `@types/react` 18 and 19, including the new block importing `ajvSchema`/`createAjv` from the subpath and `FormError`/`ErrorCode`/`StandardSchema` from the root.
- `bash test-runtime/check-matrix.sh` (React 19.2.8): 216 passed, 1 skipped (the React-18-only PropTypes check from #88).
- Tarball (`yarn pack` + `tar -tzf`): `package/dist/providers/ajv/index.js`, `package/dist/providers/ajv/index.d.ts`, `package/dist/core/{errors,standard-schema}.{js,d.ts}` present; `dist/index.js` does not import `providers/`.

## Not in this PR

- Wiring into `<Form>` / `useForm`, the store, hook-based `<Field>`/`<FieldError>`, the `/core` entry, relocation of the helpers — PR 3 (`v1-useform-store`).
- README / migration guide — PR 4.
